### PR TITLE
Weight server performance enhancement

### DIFF
--- a/ek-base/src/error.rs
+++ b/ek-base/src/error.rs
@@ -3,7 +3,7 @@ use deadpool::PoolError;
 use diesel;
 use diesel_async::pooled_connection::deadpool;
 use opendal;
-use std::{error, fmt::Write, string};
+use std::{fmt::Write, string};
 use tokio::task::JoinError;
 use tonic::Status;
 

--- a/ek-base/src/error.rs
+++ b/ek-base/src/error.rs
@@ -58,6 +58,9 @@ pub enum EKError {
 
     #[error("json error")]
     JsonError(#[from] serde_json::Error),
+
+    #[error("parse int error")]
+    ParseIntError(#[from] std::num::ParseIntError),
 }
 
 pub type EKResult<T> = std::result::Result<T, EKError>;

--- a/ek-cli/src/main.rs
+++ b/ek-cli/src/main.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{mem::transmute, path::PathBuf};
 
 use ek_db::weight_srv;
 
@@ -32,7 +32,8 @@ async fn main() {
 
     let res = match cli.command {
         Command::WeightServer { host, port, model } => {
-            weight_srv::listen(&model, (host, port)).await
+            let model: &[PathBuf] = unsafe { transmute(model.as_slice()) };
+            weight_srv::listen(model, (host, port)).await
         }
     };
     if let Err(e) = res {

--- a/ek-db/src/safetensor/transformer.rs
+++ b/ek-db/src/safetensor/transformer.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, mem::transmute, path::PathBuf, sync::Arc};
 use actix_web::{HttpResponse, Responder, body::BoxBody, http::header::ContentType};
 use ek_base::error::{EKError, EKResult};
 use memmap2::{Mmap, MmapOptions};
+use moka::future::Cache;
 use once_cell::sync::OnceCell;
 use safetensors::{SafeTensors, tensor::TensorView};
 use tokio::fs::File;
@@ -141,7 +142,41 @@ impl TransformerPretrained<'_> {
             let tv = &st_data.safetensors().tensor(key.as_str()).unwrap();
             safetensors::tensor::serialize([("data", tv)].to_vec(), &None)?
         };
+        Ok(serialized)
+    }
 
+    async fn construct_expert_key(
+        &self,
+        layer_id: usize,
+        expert_id: usize,
+    ) -> EKResult<Vec<String>> {
+        let key_up = format!(
+            "model.layers.{}.mlp.experts.{}.up_proj.weight",
+            layer_id, expert_id
+        );
+        let key_gate = format!(
+            "model.layers.{}.mlp.experts.{}.down_proj.weight",
+            layer_id, expert_id
+        );
+        let key_down = format!(
+            "model.layers.{}.mlp.experts.{}.gate_proj.weight",
+            layer_id, expert_id
+        );
+
+        Ok(vec![key_down, key_gate, key_up])
+    }
+
+    pub async fn get_expert(&self, layer_id: usize, eid: usize) -> EKResult<Vec<u8>> {
+        let keys = self.construct_expert_key(layer_id, eid).await?;
+        let mut tensors = vec![];
+
+        for key in keys.iter() {
+            let st = self.get_safetensor(key.clone()).await?;
+            let st: &SafeTensorWithData = unsafe { transmute(st.as_ref()) };
+            let tensor = st.safetensors().tensor(key)?;
+            tensors.push((key.clone(), tensor));
+        }
+        let serialized = safetensors::tensor::serialize(tensors, &None)?;
         Ok(serialized)
     }
 }
@@ -172,5 +207,34 @@ mod test {
             .unwrap();
 
         assert_eq!(tv.shape(), &[16, 8]);
+    }
+
+    #[tokio::test]
+    async fn test_get_expert() {
+        let root = workspace_root();
+        let test_model = root.join("ek-db").join("resources").join("ds-tiny");
+        let desc = TransformerModelDesc {
+            root: test_model.clone(),
+            ..TransformerModelDesc::default()
+        };
+        let pretrained: TransformerPretrained =
+            TransformerPretrained::try_from_desc(&desc).unwrap();
+        let tensor = pretrained.get_expert(21, 97).await.unwrap();
+        let st = safetensors::SafeTensors::deserialize(&tensor).unwrap();
+        let names = st.names();
+        assert_eq!(names.len(), 3);
+        let expected = vec![
+            "model.layers.21.mlp.experts.97.gate_proj.weight",
+            "model.layers.21.mlp.experts.97.down_proj.weight",
+            "model.layers.21.mlp.experts.97.up_proj.weight",
+        ];
+
+        for name in expected {
+            assert!(names.contains(&&name.to_string()));
+        }
+        let tensor = st
+            .tensor("model.layers.21.mlp.experts.97.down_proj.weight")
+            .unwrap();
+        assert_eq!(tensor.shape(), &[16, 8]);
     }
 }

--- a/ek-db/src/weight_srv/mod.rs
+++ b/ek-db/src/weight_srv/mod.rs
@@ -1,5 +1,5 @@
 mod manager;
-use std::{net::ToSocketAddrs, path::PathBuf, sync::Arc, vec};
+use std::{net::ToSocketAddrs, path::PathBuf};
 
 use actix_web::{App, HttpRequest, HttpServer, get, web};
 use ek_base::error::EKResult;
@@ -9,55 +9,40 @@ use tokio::sync::OnceCell;
 #[get("/weight/{model}/{key}")]
 async fn weight_load(
     req: HttpRequest,
-    wm: web::Data<Arc<WeightManager<'static>>>,
+    wm: web::Data<&'static WeightManager<'static>>,
 ) -> EKResult<Vec<u8>> {
     let model = req.match_info().get("model").unwrap();
     let key = req.match_info().get("key").unwrap();
-    let tv = wm.load(model.to_owned(), key.to_owned()).await?;
+    let pretrained = wm.load_pretrained(model.to_owned()).await?;
+    let tv = pretrained.read().await.get_layer(key.to_owned()).await?;
     Ok(tv)
 }
 
-async fn load_manager(roots: &[PathBuf]) -> Arc<WeightManager<'static>> {
-    static WM_CELL: OnceCell<Arc<WeightManager<'static>>> = OnceCell::const_new();
-    let wm = WM_CELL
-        .get_or_init(|| async {
-            let mut valid = vec![];
-            for root in roots.iter() {
-                if !root.exists() {
-                    log::warn!("model path not found {:?} ", root.to_str());
-                    continue;
-                }
-                valid.push(root.clone());
-            }
-            for a in &valid {
-                log::info!("model path found {:?}", a.to_str());
-            }
-            let res = WeightManager::new(&valid).await.unwrap();
-            Arc::new(res)
-        })
-        .await;
-    wm.clone()
+async fn load_manager(roots: &'static [PathBuf]) -> &'static WeightManager<'static> {
+    static WM_CELL: OnceCell<WeightManager<'static>> = OnceCell::const_new();
+
+    (WM_CELL
+        .get_or_init(|| async { WeightManager::new(roots).await.unwrap() })
+        .await) as _
 }
 
-pub async fn listen<A: ToSocketAddrs>(roots: &[PathBuf], addr: A) -> std::io::Result<()> {
+pub async fn listen<A: ToSocketAddrs>(roots: &'static [PathBuf], addr: A) -> std::io::Result<()> {
     let wm = load_manager(roots).await;
     let addr = addr.to_socket_addrs().unwrap().collect::<Vec<_>>();
     log::info!("starting weight server.");
     for a in addr.iter() {
         log::info!("listening on {}", a);
     }
-    HttpServer::new(move || {
-        App::new()
-            .app_data(web::Data::new(wm.clone()))
-            .service(weight_load)
-    })
-    .bind(addr.as_slice())?
-    .run()
-    .await
+    HttpServer::new(move || App::new().app_data(web::Data::new(wm)).service(weight_load))
+        .bind(addr.as_slice())?
+        .run()
+        .await
 }
 
 #[cfg(test)]
 mod test {
+    use std::mem::transmute;
+
     use super::*;
 
     use actix_web::{App, body::to_bytes, http::header::ContentType, test};
@@ -66,14 +51,12 @@ mod test {
     #[actix_web::test]
     async fn test_index_get() {
         let root = workspace_root();
-        let test_model = root.join("ek-db").join("resources").join("ds-tiny");
-        let wm = load_manager(&[test_model]).await;
-        let app = test::init_service(
-            App::new()
-                .app_data(web::Data::new(wm.clone()))
-                .service(weight_load),
-        )
-        .await;
+        let test_model: PathBuf = root.join("ek-db").join("resources").join("ds-tiny");
+        let tm = vec![test_model.clone()];
+        let tm: &'static [PathBuf] = unsafe { transmute(tm.as_slice()) };
+        let wm = load_manager(tm).await;
+        let app =
+            test::init_service(App::new().app_data(web::Data::new(wm)).service(weight_load)).await;
         let req = test::TestRequest::default()
             .uri("/weight/ds-tiny/model.layers.21.mlp.experts.94.down_proj.weight")
             .insert_header(ContentType::plaintext())

--- a/ek-db/src/weight_srv/mod.rs
+++ b/ek-db/src/weight_srv/mod.rs
@@ -6,8 +6,21 @@ use ek_base::error::EKResult;
 use manager::WeightManager;
 use tokio::sync::OnceCell;
 
+#[get("/expert/{model}/{layer}/{expert}")]
+async fn load_expert(
+    req: HttpRequest,
+    wm: web::Data<&'static WeightManager<'static>>,
+) -> EKResult<Vec<u8>> {
+    let model = req.match_info().get("model").unwrap();
+    let layer = req.match_info().get("layer").unwrap().parse::<usize>()?;
+    let expert = req.match_info().get("expert").unwrap().parse::<usize>()?;
+    let pretrained = wm.load_pretrained(model.to_owned()).await?;
+    let tv = pretrained.read().await.get_expert(layer, expert).await?;
+    Ok(tv)
+}
+
 #[get("/weight/{model}/{key}")]
-async fn weight_load(
+async fn load_layer(
     req: HttpRequest,
     wm: web::Data<&'static WeightManager<'static>>,
 ) -> EKResult<Vec<u8>> {
@@ -33,10 +46,15 @@ pub async fn listen<A: ToSocketAddrs>(roots: &'static [PathBuf], addr: A) -> std
     for a in addr.iter() {
         log::info!("listening on {}", a);
     }
-    HttpServer::new(move || App::new().app_data(web::Data::new(wm)).service(weight_load))
-        .bind(addr.as_slice())?
-        .run()
-        .await
+    HttpServer::new(move || {
+        App::new()
+            .app_data(web::Data::new(wm))
+            .service(load_layer)
+            .service(load_expert)
+    })
+    .bind(addr.as_slice())?
+    .run()
+    .await
 }
 
 #[cfg(test)]
@@ -56,7 +74,7 @@ mod test {
         let tm: &'static [PathBuf] = unsafe { transmute(tm.as_slice()) };
         let wm = load_manager(tm).await;
         let app =
-            test::init_service(App::new().app_data(web::Data::new(wm)).service(weight_load)).await;
+            test::init_service(App::new().app_data(web::Data::new(wm)).service(load_layer)).await;
         let req = test::TestRequest::default()
             .uri("/weight/ds-tiny/model.layers.21.mlp.experts.94.down_proj.weight")
             .insert_header(ContentType::plaintext())
@@ -70,5 +88,42 @@ mod test {
         let tv = st.tensor("data").unwrap();
 
         assert_eq!(tv.shape(), &[16, 8]);
+    }
+
+    #[actix_web::test]
+    async fn test_load_expert() {
+        let root = workspace_root();
+        let test_model: PathBuf = root.join("ek-db").join("resources").join("ds-tiny");
+        let tm = vec![test_model.clone()];
+        let tm: &'static [PathBuf] = unsafe { transmute(tm.as_slice()) };
+        let wm = load_manager(tm).await;
+        let app =
+            test::init_service(App::new().app_data(web::Data::new(wm)).service(load_expert)).await;
+        let req = test::TestRequest::default()
+            .uri("/expert/ds-tiny/18/32")
+            .insert_header(ContentType::plaintext())
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        let success = resp.status().is_success();
+        assert!(success);
+        let body = resp.into_body();
+        let res = to_bytes(body).await.unwrap();
+        let st = safetensors::SafeTensors::deserialize(&res).unwrap();
+
+        let names = st.names();
+        assert_eq!(names.len(), 3);
+        let expected = vec![
+            "model.layers.18.mlp.experts.32.gate_proj.weight",
+            "model.layers.18.mlp.experts.32.down_proj.weight",
+            "model.layers.18.mlp.experts.32.up_proj.weight",
+        ];
+
+        for name in expected {
+            assert!(names.contains(&&name.to_string()));
+        }
+        let tensor = st
+            .tensor("model.layers.18.mlp.experts.32.down_proj.weight")
+            .unwrap();
+        assert_eq!(tensor.shape(), &[16, 8]);
     }
 }


### PR DESCRIPTION
This PR improves Weight-Srv Performance enhancement by

1. manually manage lifetime: which allow as remove `&'mut` for read path and allow concurrent reading.
2. add `load_expert` api to reduce RTT while loading MoE model.