### PR TITLE
Fix deprecated layer name in qwen3, adapt to latest weight server

### DIFF
--- a/ek-integration/expertkit_torch/expertkit_torch/models/deepseek_v3/model.py
+++ b/ek-integration/expertkit_torch/expertkit_torch/models/deepseek_v3/model.py
@@ -243,13 +243,13 @@ if __name__ == "__main__":
         "--model_name",
         type=str,
         required=True,
-        help="ExpertKit address. like http://localhost:5002",
+        help="The name of the model used in ExpertKit. like qwen3",
     )
     parser.add_argument(
         "--seq",
         type=int,
         required=False,
-        help="ExpertKit address. like http://localhost:5002",
+        help="Batch size for evaluation.",
         default=1,
     )
     args = parser.parse_args()

--- a/ek-integration/expertkit_torch/expertkit_torch/models/qwen3_moe.py
+++ b/ek-integration/expertkit_torch/expertkit_torch/models/qwen3_moe.py
@@ -33,18 +33,24 @@ from expertkit_torch.grpc_client import ExpertKitClient
 
 set_verbosity_error()
 
+# default timeout interval for ek client, in seconds
+DEFAULT_TIMEOUT_INTVAL = 100
 layer_idx = 0
 
 
-def intercept_moe(with_ek: bool):
+def intercept_moe(
+    enable_ek: bool = True,
+    ek_addr: str = "localhost:5002",
+    ek_model_name: str = "qwen3",    
+):
     class Intercepted(nn.Module):
         client: ExpertKitClient = None
 
         def __init__(self, config):
             super().__init__()
             global layer_idx
-            if with_ek and Intercepted.client is None:
-                Intercepted.client = ExpertKitClient(config.ek_addr, 10)
+            if enable_ek and Intercepted.client is None:
+                Intercepted.client = ExpertKitClient(ek_addr, DEFAULT_TIMEOUT_INTVAL)
             self.layer_id = layer_idx
             layer_idx += 1
             self.num_experts = config.num_experts
@@ -52,7 +58,7 @@ def intercept_moe(with_ek: bool):
             self.norm_topk_prob = config.norm_topk_prob
 
             self.gate = nn.Linear(config.hidden_size, config.num_experts, bias=False)
-            if not with_ek:
+            if not enable_ek:
                 self.experts = nn.ModuleList(
                     [
                         qwen3_moe.Qwen3MoeMLP(
@@ -79,15 +85,11 @@ def intercept_moe(with_ek: bool):
             for seq_idx in range(total_seq_len):
                 eids = selected_experts[seq_idx].tolist()
                 ids = [
-                    f"model-layer{self.layer_id}-expert{expert_idx}.safetensors"
+                    f"{ek_model_name}/l{self.layer_id}-e{expert_idx}"
                     for expert_idx in eids
                 ]
                 expert_ids.append(ids)
 
-            for seq_idx in range(total_seq_len):
-                eids = selected_experts[seq_idx].tolist()
-
-            # TODO
             outputs = self.client.forward_expert(
                 expert_ids=expert_ids, hidden_state=hidden_states
             )
@@ -158,7 +160,7 @@ def intercept_moe(with_ek: bool):
                 selected_experts, num_classes=self.num_experts
             ).permute(2, 1, 0)
 
-            if with_ek:
+            if enable_ek:
                 final = self.ek_forward(
                     hidden_states=hidden_states,
                     routing_weights=routing_weights,
@@ -184,8 +186,20 @@ def intercept_moe(with_ek: bool):
     setattr(qwen3_moe, "Qwen3MoeSparseMoeBlock", Intercepted)
 
 
-def evaluate(*, model_path="./", prompt="What is MoE Model?", enable_ek=True):
-    intercept_moe(enable_ek)
+def evaluate(
+    *, 
+    model_path="./", 
+    prompt="What is MoE Model?", 
+
+    enable_ek=True,
+    ek_addr="localhost:5002",
+    ek_model_name="qwen3"
+):
+    intercept_moe(
+        enable_ek=enable_ek,
+        ek_addr=ek_addr,
+        ek_model_name=ek_model_name,
+    )
     # load the tokenizer and the model
     tokenizer = AutoTokenizer.from_pretrained(
         pretrained_model_name_or_path=model_path,
@@ -212,13 +226,15 @@ def evaluate(*, model_path="./", prompt="What is MoE Model?", enable_ek=True):
     print("elapsed time:", end - now)
     output_ids = generated_ids[0][len(model_inputs.input_ids[0]) :].tolist()
 
+    thinking_finish = False
     # parsing thinking content
     try:
         # rindex finding 151668 (</think>)
         index = len(output_ids) - output_ids[::-1].index(151668)
+        thinking_finish = True
     except ValueError:
-        print("value error")
-        index = 0
+        # thinking not finish
+        index = len(output_ids) - 1
 
     thinking_content = tokenizer.decode(
         output_ids[:index], skip_special_tokens=True
@@ -226,7 +242,8 @@ def evaluate(*, model_path="./", prompt="What is MoE Model?", enable_ek=True):
     content = tokenizer.decode(output_ids[index:], skip_special_tokens=True).strip("\n")
 
     print("thinking content:", thinking_content)
-    print("content:", content)
+    if thinking_finish:
+        print("content:", content)
     return {
         "thinking_content": thinking_content,
         "content": content,
@@ -247,5 +264,24 @@ if __name__ == "__main__":
         action=argparse.BooleanOptionalAction,
         help="Enable ExpertKit.",
     )
+    parser.add_argument(
+        "--ek_model_name",
+        type=str,
+        default="qwen3",
+        help="The name of the model used in ExpertKit.",
+    )
+    parser.add_argument(
+        "--ek_addr",
+        type=str,
+        default="localhost:5002",
+        help="The address of the ExpertKit server.",
+    )
     args = parser.parse_args()
-    evaluate(model_path=args.model_path, enable_ek=args.enable_ek)
+    evaluate(
+        model_path=args.model_path,
+        prompt="What is MoE Model?", 
+
+        enable_ek=args.enable_ek,
+        ek_addr=args.ek_addr,
+        ek_model_name=args.ek_model_name,
+    )


### PR DESCRIPTION
Fix deprecated qwen3 layer name
```
from model-layer{self.layer_id}-expert{expert_idx}.safetensors
-->
{model_name}/l{layer}-e{expert}
```