### PR TITLE
Fix: Resolve slow expert loading

### DIFF
--- a/ek-cli/src/main.rs
+++ b/ek-cli/src/main.rs
@@ -84,10 +84,11 @@ async fn main() {
     }
     env_logger::init_from_env(env_logger::Env::default().default_filter_or("info"));
     let mut config_src = vec![];
-    let env_config = std::option_env!("EK_CONFIG");
-    if let Some(path) = env_config {
-        config_src.push(path.to_string());
+
+    if let Ok(path) = std::env::var("EK_CONFIG") {
+        config_src.push(path);
     }
+    
     if let Some(path) = cli.config {
         config_src.push(path.to_string());
     }

--- a/ek-computation/src/ffn/expert_torch.rs
+++ b/ek-computation/src/ffn/expert_torch.rs
@@ -13,7 +13,7 @@ use once_cell::sync::OnceCell;
 use safetensors::tensor::TensorView;
 use tch::{
     self, Tensor,
-    nn::{self, Module},
+    nn::{self, Module, LinearConfig},
 };
 
 use super::{DType, Device, EkTensor, Expert, ExpertShape, ExpertWeight, FromSafeTensor};
@@ -201,9 +201,21 @@ impl TorchFFN {
                 let hidden_dim = self.intermediate_dim as i64;
                 let vs = nn::VarStore::new(tch::Device::Cpu);
                 let path = vs.root();
-                let mut w1 = nn::linear(&path / "up", dim, hidden_dim, Default::default());
-                let mut w2 = nn::linear(&path / "down", hidden_dim, dim, Default::default());
-                let mut w3 = nn::linear(&path / "gate", dim, hidden_dim, Default::default());
+                let mut w1 = nn::linear(&path / "up", dim, hidden_dim, LinearConfig{
+                    ws_init: nn::Init::Const(0.0),
+                    bs_init: None,
+                    bias: false,
+                });
+                let mut w2 = nn::linear(&path / "down", hidden_dim, dim, LinearConfig{
+                    ws_init: nn::Init::Const(0.0),
+                    bs_init: None,
+                    bias: false,
+                });
+                let mut w3 = nn::linear(&path / "gate", dim, hidden_dim, LinearConfig{
+                    ws_init: nn::Init::Const(0.0),
+                    bs_init: None,
+                    bias: false,
+                });
                 w1.ws = self
                     .weight
                     .up_w


### PR DESCRIPTION
Fix: Resolve slow DeepSeek model loading
The issue was caused by Init large Linear layer. more specific, tch::Linear initialization using DEFAULT_KAIMING_UNIFORM,
which significantly increased initialization time.

Fix: replace option_env! with std::env::var for runtime config loading