### PR TITLE
Switch to stable rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,6 +634,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,6 +705,33 @@ checksum = "8f10f8c9340e31fc120ff885fcdb54a0b48e474bbd77cab557f0c30a3e569402"
 dependencies = [
  "parse-zoneinfo",
  "phf_codegen",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -911,6 +950,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1257,6 +1329,7 @@ dependencies = [
  "opentelemetry_sdk",
  "ort",
  "prost",
+ "rand 0.9.1",
  "safetensors 0.5.3",
  "serde",
  "serde_json",
@@ -1308,6 +1381,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "clap",
+ "criterion",
  "diesel",
  "diesel-async",
  "ek_base",
@@ -2268,6 +2342,15 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -2825,6 +2908,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opendal"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3265,6 +3354,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1691dd09e82f428ce8d6310bd6d5da2557c82ff17694d2a32cad7242aea89f"
 dependencies = [
  "array-init-cursor",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -5161,6 +5278,16 @@ checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ ort = { version = "2.0.0-rc.9", features = [
     "half",
 ] }
 polars = { version = "0.46.0", features = [
-    "simd",
     "sql",
     "ndarray",
     "lazy",
@@ -52,6 +51,7 @@ serde_json = "1.0.140"
 async-channel = "2.3.1"
 once_cell = "1.21.3"
 config = "0.15.11"
+criterion = { version = "0.6.0", features = ["html_reports"] }
 memmap2 = "0.9.5"
 actix-web = "4.10.2"
 actix-http = "3.10.0"

--- a/ek-benchmark/src/main.rs
+++ b/ek-benchmark/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(f16)]
-
 mod bench;
 use std::{
     fs::File,

--- a/ek-cli/Cargo.toml
+++ b/ek-cli/Cargo.toml
@@ -15,6 +15,7 @@ ek_base = { path = "../ek-base" }
 
 tokio = { workspace = true }
 log = { workspace = true }
+rand = { workspace = true }
 env_logger = { workspace = true }
 
 diesel = { workspace = true }

--- a/ek-cli/src/main.rs
+++ b/ek-cli/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(random)]
 use std::{env, mem::transmute, path::PathBuf};
 mod db;
 mod doctor;

--- a/ek-cli/src/schedule/mod.rs
+++ b/ek-cli/src/schedule/mod.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, random::random, str::FromStr};
+use std::{path::PathBuf, str::FromStr};
 
 use clap::Subcommand;
 use ek_base::{
@@ -16,6 +16,7 @@ use ek_computation::{
 use ek_db::{safetensor::ExpertKey, weight_srv::client::WeightSrvClient};
 use indicatif::ProgressBar;
 use log::info;
+use rand::random;
 use serde::Deserialize;
 use tokio::task::JoinSet;
 use tonic::transport::Endpoint;

--- a/ek-computation/Cargo.toml
+++ b/ek-computation/Cargo.toml
@@ -53,6 +53,12 @@ tower = { workspace = true }
 [build-dependencies]
 tonic-build = "*"
 
+[dev-dependencies]
+criterion = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "staticlib", "rlib"]
+
+[[bench]]
+name = "activate"
+harness = false

--- a/ek-computation/benches/activate.rs
+++ b/ek-computation/benches/activate.rs
@@ -1,0 +1,15 @@
+use ek_computation::ffn::expert_torch::w8a16_activate;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+pub fn stress(c: &mut Criterion) {
+    let tv1 = tch::Tensor::randn(vec![7168, 2048], (tch::Kind::Float, tch::Device::Cpu));
+    let tv2 = tch::Tensor::randn(vec![56, 16], (tch::Kind::Float, tch::Device::Cpu));
+    
+    c.bench_function("stress", |b| b.iter(|| {
+        let _ = std::hint::black_box(w8a16_activate(&tv1, &tv2, 128));
+    }));
+}
+
+criterion_group!(benches, stress);
+criterion_main!(benches);

--- a/ek-computation/src/bin/worker.rs
+++ b/ek-computation/src/bin/worker.rs
@@ -1,4 +1,3 @@
-#![feature(pattern)]
 use ek_base::error::EKResult;
 use ek_computation::worker::worker_main;
 

--- a/ek-computation/src/controller/service/control.rs
+++ b/ek-computation/src/controller/service/control.rs
@@ -1,10 +1,9 @@
-use std::random::random;
-
 use ek_base::{
     config::get_ek_settings,
     error::{EKError, EKResult},
 };
 use ek_db::{safetensor::ExpertKey, weight_srv::client::WeightSrvClient};
+use rand::random;
 use tokio::task::JoinSet;
 
 use crate::{

--- a/ek-computation/src/ffn/expert_torch.rs
+++ b/ek-computation/src/ffn/expert_torch.rs
@@ -142,8 +142,6 @@ mod test {
     use ek_base::utils::workspace_root;
     use safetensors::SafeTensors;
     use tch::IndexOp;
-    use test::Bencher;
-    extern crate test;
 
     use crate::{
         backend::{Device, EkTensor},
@@ -217,17 +215,5 @@ mod test {
             .abs()
             .double_value(&[]);
         assert!(diff < 0.2);
-    }
-
-    #[bench]
-    fn pressure_test(b: &mut Bencher) {
-        let tv1 = tch::Tensor::randn(vec![7168, 2048], (tch::Kind::Float, tch::Device::Cpu));
-        let tv2 = tch::Tensor::randn(vec![56, 16], (tch::Kind::Float, tch::Device::Cpu));
-        let _ = w8a16_activate(&tv1, &tv2, 128);
-        let _ = w8a16_activate(&tv1, &tv2, 128);
-        let _ = w8a16_activate(&tv1, &tv2, 128);
-        b.iter(|| {
-            let _ = w8a16_activate(&tv1, &tv2, 128);
-        });
     }
 }

--- a/ek-computation/src/lib.rs
+++ b/ek-computation/src/lib.rs
@@ -1,7 +1,3 @@
-#![feature(pattern)]
-#![feature(random)]
-#![feature(test)]
-
 pub mod backend;
 pub mod controller;
 pub mod ffn;

--- a/ek-db/src/lib.rs
+++ b/ek-db/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(get_mut_unchecked)]
 pub mod dal;
 pub mod safetensor;
 pub mod weight_srv;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly-2024-12-31"


### PR DESCRIPTION
Closes #67

Key Changes:
- Remove all unused features (now it still compiles with stable rustc)
- Use criterion for benchmarking (builtin `bench` is already deprecated and will lead to hard error in the future)

![图片](https://github.com/user-attachments/assets/64499039-cd8b-49f8-a25c-51d43aa1427a)

I am not sure if `simd` in `polars` really matters for benchmarking. I removed it as it requires nightly toolchain. It seems that this feature acclerates the statistics but does nothing for expert forwarding (in `ek-benchmark`).