### PR TITLE
perf: use ggml operators to optimize cpu ffn forwarding

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ek-ggml/ggml"]
+	path = ek-ggml/ggml
+	url = https://github.com/ggml-org/ggml.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,6 +505,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f72209734318d0b619a5e0f5129918b848c416e122a3c4ce054e03cb87b726f"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +681,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,6 +764,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +813,15 @@ name = "clap_lex"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -1349,6 +1398,7 @@ dependencies = [
  "diesel-async",
  "ek-base",
  "ek-db",
+ "ek-ggml",
  "env_logger",
  "half",
  "lazy_static",
@@ -1392,6 +1442,15 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "ek-ggml"
+version = "0.1.0"
+dependencies = [
+ "bindgen",
+ "cmake",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -2528,6 +2587,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2608,6 +2673,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,13 @@
 [workspace]
 resolver = "2"
-members = ["ek-base", "ek-benchmark", "ek-cli", "ek-computation", "ek-db"]
+members = [
+    "ek-base",
+    "ek-benchmark",
+    "ek-cli",
+    "ek-computation",
+    "ek-db",
+    "ek-ggml",
+]
 default-members = ["ek-cli"]
 
 [workspace.package]
@@ -18,14 +25,17 @@ ek-benchmark = { path = "ek-benchmark" }
 ek-cli = { path = "ek-cli" }
 ek-computation = { path = "ek-computation" }
 ek-db = { path = "ek-db" }
+ek-ggml = { path = "ek-ggml" }
 
 # External dependencies (alphabetical order)
 actix-http = "3.10.0"
 actix-web = "4.10.2"
 async-channel = "2.3.1"
 async-trait = "0.1.88"
+bindgen = "0.72"
 bytes = "1.10.1"
 clap = { version = "4.5.31", features = ["derive"] }
+cmake = "0.1"
 config = "0.15.11"
 criterion = { version = "0.6.0", features = ["html_reports"] }
 dashmap = "6.1.0"

--- a/ek-base/src/config.rs
+++ b/ek-base/src/config.rs
@@ -86,6 +86,8 @@ pub struct WorkerSettings {
     pub broadcast: String,
     pub ports: WorkerPorts,
     pub device: String,
+    #[serde(default = "default_backend")]
+    pub backend: String,
     #[serde(default)]
     pub drop_cache: bool,
     #[serde(default = "default_worker_metrics")]
@@ -99,6 +101,10 @@ fn default_worker_metrics() -> String {
 
 fn default_worker_channel() -> String {
     "grpc".to_string()
+}
+
+fn default_backend() -> String {
+    "torch".to_string()
 }
 
 fn default_worker_id() -> String {

--- a/ek-base/src/config.rs
+++ b/ek-base/src/config.rs
@@ -86,6 +86,8 @@ pub struct WorkerSettings {
     pub broadcast: String,
     pub ports: WorkerPorts,
     pub device: String,
+    #[serde(default)]
+    pub drop_cache: bool,
     #[serde(default = "default_worker_metrics")]
     pub metrics: String,
     pub advanced: Option<WorkerAdvancedSettings>,

--- a/ek-benchmark/src/bench.rs
+++ b/ek-benchmark/src/bench.rs
@@ -23,6 +23,7 @@ impl ExpertBenchmark {
         match &self.0 {
             ExpertBackend::Torch(exp) => exp.backend(),
             ExpertBackend::OnnxF32(onnx_exp) => onnx_exp.backend(),
+            _ => todo!(),
         }
     }
 
@@ -30,6 +31,7 @@ impl ExpertBenchmark {
         match &self.0 {
             ExpertBackend::Torch(exp) => exp.shape(),
             ExpertBackend::OnnxF32(onnx_exp) => onnx_exp.shape(),
+            _ => todo!(),
         }
     }
 
@@ -48,6 +50,7 @@ impl ExpertBenchmark {
                 let _ = onnx_exp.forward(&input);
                 start
             }
+            _ => todo!(),
         }
     }
 }

--- a/ek-benchmark/src/main.rs
+++ b/ek-benchmark/src/main.rs
@@ -113,6 +113,7 @@ fn main() {
                 .unwrap();
                 experts.push(ExpertBenchmark(ExpertBackend::OnnxF32(exp)));
             }
+            _ => todo!(),
         }
     }
     let mut bencher = Benchmarker::new(experts);

--- a/ek-computation/Cargo.toml
+++ b/ek-computation/Cargo.toml
@@ -10,6 +10,7 @@ repository = { workspace = true }
 [dependencies]
 ek-base = { workspace = true }
 ek-db = { workspace = true }
+ek-ggml = { workspace = true }
 actix-web = { workspace = true }
 async-trait = { workspace = true }
 clap = { workspace = true }

--- a/ek-computation/benches/benchmarks/xpu_ffn.rs
+++ b/ek-computation/benches/benchmarks/xpu_ffn.rs
@@ -1,4 +1,4 @@
-use std::sync::OnceLock;
+use std::{sync::OnceLock, time::Duration};
 
 use criterion::{BatchSize, Criterion};
 use ek_computation::{
@@ -8,54 +8,62 @@ use ek_computation::{
         meta::{Expert, ExpertWeight},
     },
 };
-use ek_ggml::Context;
 
-use crate::DEVICES;
+use crate::{BACKEND2DEVICES, DEVICES};
 
-const BATCH_SIZES: &[usize] = &[1, 4, 8, 16, 64];
+const BATCH_SIZES: &[usize] = &[1, 4, 8, 16, 32, 64, 128, 256, 512];
 
 pub fn bench(c: &mut Criterion) {
-    let mut group = c.benchmark_group("torch ffn w/o weight transfer");
-
-    Context::init(64 * 1024 * 1024 * 1024);
+    let mut group = c.benchmark_group("ffn w/o weight transfer");
 
     for &batch_size in BATCH_SIZES {
-        for &dev in DEVICES.keys() {
-            group.bench_function(format!("batch={batch_size}, device={dev}"), |b| {
-                // let ffn = GgmlFFN::new(
-                //     2048,
-                //     768,
-                //     ExpertWeight::from_rand_linear(
-                //         2048,
-                //         768,
-                //         ek_computation::backend::DType::Float,
-                //         DEVICES[dev],
-                //     ),
-                //     8,
-                // );
-                let ffn = TorchFFN::new(
-                    2048,
-                    768,
-                    OnceLock::new(),
-                    ExpertWeight::from_rand_linear(
-                        2048,
-                        768,
-                        ek_computation::backend::DType::Float,
-                        DEVICES[dev],
-                    ),
-                    DEVICES[dev],
-                );
-                b.iter_batched(
-                    || ffn.rand_input(batch_size).to_device(Device::CPU),
-                    |input| {
-                        let _ = std::hint::black_box(
-                            ffn.forward(&input.to_device(DEVICES[dev]))
-                                .to_device(Device::CPU),
-                        );
+        for &backend in BACKEND2DEVICES.keys() {
+            for &dev in &BACKEND2DEVICES[backend] {
+                group.bench_with_input(
+                    format!("batch={batch_size}, backend={backend} ({dev})"),
+                    &batch_size,
+                    |b, &batch_size| {
+                        if backend == "ggml" {
+                            let weight = ExpertWeight::from_rand_linear(
+                                2048,
+                                768,
+                                ek_computation::backend::DType::BFloat16,
+                                DEVICES[dev],
+                            );
+                            let ffn = GgmlFFN::new(2048, 768, weight, 8);
+                            b.iter_batched(
+                                || ffn.rand_input(batch_size).to_device(Device::CPU),
+                                |input| {
+                                    let _ = std::hint::black_box(
+                                        ffn.forward(&input.to_device(DEVICES[dev]))
+                                            .to_device(Device::CPU),
+                                    );
+                                },
+                                BatchSize::PerIteration,
+                            );
+                        } else if backend == "torch" {
+                            let weight = ExpertWeight::from_rand_linear(
+                                2048,
+                                768,
+                                ek_computation::backend::DType::BFloat16,
+                                DEVICES[dev],
+                            );
+                            let ffn =
+                                TorchFFN::new(2048, 768, OnceLock::new(), weight, DEVICES[dev]);
+                            b.iter_batched(
+                                || ffn.rand_input(batch_size).to_device(Device::CPU),
+                                |input| {
+                                    let _ = std::hint::black_box(
+                                        ffn.forward(&input.to_device(DEVICES[dev]))
+                                            .to_device(Device::CPU),
+                                    );
+                                },
+                                BatchSize::PerIteration,
+                            );
+                        }
                     },
-                    BatchSize::PerIteration,
                 );
-            });
+            }
         }
     }
 }

--- a/ek-computation/benches/benchmarks/xpu_ffn.rs
+++ b/ek-computation/benches/benchmarks/xpu_ffn.rs
@@ -8,6 +8,7 @@ use ek_computation::{
         meta::{Expert, ExpertWeight},
     },
 };
+use ek_ggml::Context;
 
 use crate::DEVICES;
 
@@ -16,9 +17,22 @@ const BATCH_SIZES: &[usize] = &[1, 4, 8, 16, 64];
 pub fn bench(c: &mut Criterion) {
     let mut group = c.benchmark_group("torch ffn w/o weight transfer");
 
+    Context::init(64 * 1024 * 1024 * 1024);
+
     for &batch_size in BATCH_SIZES {
         for &dev in DEVICES.keys() {
             group.bench_function(format!("batch={batch_size}, device={dev}"), |b| {
+                // let ffn = GgmlFFN::new(
+                //     2048,
+                //     768,
+                //     ExpertWeight::from_rand_linear(
+                //         2048,
+                //         768,
+                //         ek_computation::backend::DType::Float,
+                //         DEVICES[dev],
+                //     ),
+                //     8,
+                // );
                 let ffn = TorchFFN::new(
                     2048,
                     768,
@@ -26,7 +40,7 @@ pub fn bench(c: &mut Criterion) {
                     ExpertWeight::from_rand_linear(
                         2048,
                         768,
-                        ek_computation::backend::DType::BFloat16,
+                        ek_computation::backend::DType::Float,
                         DEVICES[dev],
                     ),
                     DEVICES[dev],

--- a/ek-computation/benches/benchmarks/xpu_ffn.rs
+++ b/ek-computation/benches/benchmarks/xpu_ffn.rs
@@ -1,9 +1,10 @@
-use std::{sync::OnceLock, time::Duration};
+use std::sync::OnceLock;
 
 use criterion::{BatchSize, Criterion};
 use ek_computation::{
     backend::{Device, EkTensor},
     ffn::{
+        expert_ggml::GgmlFFN,
         expert_torch::TorchFFN,
         meta::{Expert, ExpertWeight},
     },

--- a/ek-computation/benches/benchmarks/xpu_ffn_with_weight_transfer.rs
+++ b/ek-computation/benches/benchmarks/xpu_ffn_with_weight_transfer.rs
@@ -1,4 +1,4 @@
-use std::{sync::OnceLock, time::Duration};
+use std::sync::OnceLock;
 
 use criterion::{BatchSize, Criterion};
 use ek_computation::{

--- a/ek-computation/benches/benchmarks/xpu_ffn_with_weight_transfer.rs
+++ b/ek-computation/benches/benchmarks/xpu_ffn_with_weight_transfer.rs
@@ -15,7 +15,6 @@ const BATCH_SIZES: &[usize] = &[1, 4, 8, 16, 64, 128, 256, 512];
 
 pub fn bench(c: &mut Criterion) {
     let mut group = c.benchmark_group("torch ffn w/ weight transfer");
-    group.measurement_time(Duration::from_secs(60));
 
     for &batch_size in BATCH_SIZES {
         for &dev in DEVICES.keys() {

--- a/ek-computation/benches/main.rs
+++ b/ek-computation/benches/main.rs
@@ -5,6 +5,14 @@ use std::{collections::HashMap, sync::LazyLock};
 use criterion::{criterion_group, criterion_main};
 use ek_computation::backend::Device;
 
+pub static BACKEND2DEVICES: LazyLock<HashMap<&'static str, Vec<&'static str>>> =
+    LazyLock::new(|| {
+        let mut backends = HashMap::new();
+        backends.insert("ggml", vec!["cpu"]);
+        backends.insert("torch", vec!["cpu", "cuda:0"]);
+        backends
+    });
+
 pub static DEVICES: LazyLock<HashMap<&'static str, Device>> = LazyLock::new(|| {
     let mut devices = HashMap::new();
     devices.insert("cpu", Device::CPU);

--- a/ek-computation/src/backend/ggml/ggml_safetensors.rs
+++ b/ek-computation/src/backend/ggml/ggml_safetensors.rs
@@ -1,0 +1,71 @@
+use ek_ggml::Kind;
+use safetensors::{Dtype, View};
+
+use crate::backend::ggml::GgmlTensor;
+
+pub fn ggml_kind_to_dtype(kind: Kind) -> Result<Dtype, Kind> {
+    match kind {
+        Kind::F32 => Ok(Dtype::F32),
+        Kind::BF16 => Ok(Dtype::BF16),
+        _ => Err(kind),
+    }
+}
+
+pub fn dtype_to_ggml_kind(dtype: Dtype) -> Result<Kind, Dtype> {
+    match dtype {
+        Dtype::F32 => Ok(Kind::F32),
+        Dtype::BF16 => Ok(Kind::BF16),
+        _ => Err(dtype),
+    }
+}
+
+struct SafeView<'a> {
+    tensor_data: &'a [u8],
+    shape: Vec<usize>,
+    dtype: Dtype,
+}
+
+impl<'a> SafeView<'a> {
+    fn new(tensor: &'a GgmlTensor) -> Self {
+        Self {
+            tensor_data: tensor.data.as_ref(),
+            shape: tensor.shape.iter().map(|&s| s as usize).collect(),
+            dtype: ggml_kind_to_dtype(tensor.kind).unwrap(),
+        }
+    }
+}
+
+impl View for SafeView<'_> {
+    fn data(&self) -> std::borrow::Cow<'_, [u8]> {
+        std::borrow::Cow::Borrowed(self.tensor_data)
+    }
+
+    fn data_len(&self) -> usize {
+        self.tensor_data.len()
+    }
+
+    fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    fn dtype(&self) -> Dtype {
+        self.dtype
+    }
+}
+
+pub fn write_safetensors<S>(
+    tensors: &[(S, &GgmlTensor)],
+) -> Result<Vec<u8>, Box<dyn std::error::Error>>
+where
+    S: AsRef<str>,
+{
+    let views = tensors
+        .iter()
+        .map(|(name, tensor)| {
+            let view = SafeView::new(tensor);
+            Ok::<(&str, SafeView), Box<dyn std::error::Error>>((name.as_ref(), view))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let result = safetensors::tensor::serialize(views, &None)?;
+    Ok(result)
+}

--- a/ek-computation/src/backend/ggml/mod.rs
+++ b/ek-computation/src/backend/ggml/mod.rs
@@ -6,6 +6,7 @@ impl From<crate::backend::DType> for Kind {
     fn from(value: crate::backend::DType) -> Self {
         match value {
             crate::backend::DType::Float => Kind::F32,
+            crate::backend::DType::BFloat16 => Kind::BF16,
             _ => unimplemented!(),
         }
     }
@@ -15,6 +16,7 @@ impl From<ek_ggml::Kind> for crate::backend::DType {
     fn from(value: Kind) -> Self {
         match value {
             Kind::F32 => crate::backend::DType::Float,
+            Kind::BF16 => crate::backend::DType::BFloat16,
         }
     }
 }
@@ -90,26 +92,15 @@ impl EkTensor for GgmlTensor {
 
     fn from_tensor_view(tv: &safetensors::tensor::TensorView<'_>) -> Self {
         let shape = tv.shape().iter().map(|&s| s as i64).collect::<Vec<_>>();
-        let data = match tv.dtype() {
-            safetensors::tensor::Dtype::F32 => tv.data().to_vec(),
-            safetensors::tensor::Dtype::BF16 => {
-                // bf16 -> f32
-                let f32_data = tv
-                    .data()
-                    .chunks_exact(2)
-                    .flat_map(|chunk| {
-                        let bf16 = u16::from_le_bytes([chunk[0], chunk[1]]);
-                        f32::from_bits((bf16 as u32) << 16).to_le_bytes()
-                    })
-                    .collect();
-                f32_data
-            }
+        let kind = match tv.dtype() {
+            safetensors::tensor::Dtype::F32 => Kind::F32,
+            safetensors::tensor::Dtype::BF16 => Kind::BF16,
             _ => unimplemented!(),
         };
         GgmlTensor {
-            data,
+            data: tv.data().to_vec(),
             shape,
-            kind: Kind::F32,
+            kind,
         }
     }
 

--- a/ek-computation/src/backend/ggml/mod.rs
+++ b/ek-computation/src/backend/ggml/mod.rs
@@ -1,0 +1,124 @@
+use ek_ggml::Kind;
+
+use crate::backend::{EkTensor, FromSafeTensor};
+
+impl From<crate::backend::DType> for Kind {
+    fn from(value: crate::backend::DType) -> Self {
+        match value {
+            crate::backend::DType::Float => Kind::F32,
+            _ => unimplemented!(),
+        }
+    }
+}
+
+impl From<ek_ggml::Kind> for crate::backend::DType {
+    fn from(value: Kind) -> Self {
+        match value {
+            Kind::F32 => crate::backend::DType::Float,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GgmlTensor {
+    pub(crate) data: Vec<u8>,
+    pub(crate) shape: Vec<i64>,
+    pub(crate) kind: Kind,
+}
+
+impl GgmlTensor {
+    pub fn empty(shape: &[usize], dtype: crate::backend::DType) -> Option<Self> {
+        let shape_i64: Vec<i64> = shape.iter().map(|&s| s as i64).collect();
+        let kind: Kind = dtype.into();
+        Some(Self {
+            data: Vec::new(),
+            shape: shape_i64,
+            kind,
+        })
+    }
+}
+
+impl FromSafeTensor for GgmlTensor {
+    fn lookup_suffix(
+        st: &safetensors::SafeTensors,
+        name: &[&str],
+        _dev: super::Device,
+    ) -> Option<Self> {
+        let idx = st
+            .names()
+            .iter()
+            .position(|x| name.iter().any(|v| x.ends_with(v)));
+        let tensors = st.tensors();
+        if let Some(x) = idx {
+            let (_, view) = tensors.get(x).unwrap();
+            Some(Self::from_tensor_view(view))
+        } else {
+            None
+        }
+    }
+}
+
+impl EkTensor for GgmlTensor {
+    fn rand(shape: Vec<usize>, dtype: crate::backend::DType, dev: crate::backend::Device) -> Self {
+        assert_eq!(dev, crate::backend::Device::CPU);
+        let mut data = vec![0u8; shape.iter().product::<usize>() * dtype.size()];
+        for elem in data.iter_mut() {
+            *elem = rand::random();
+        }
+        GgmlTensor {
+            data,
+            shape: shape.into_iter().map(|s| s as i64).collect(),
+            kind: dtype.into(),
+        }
+    }
+
+    fn shape(&self) -> Vec<usize> {
+        self.shape.iter().map(|&s| s as usize).collect()
+    }
+
+    fn serialize(&self) -> Vec<u8> {
+        self.data.clone()
+    }
+
+    fn from_raw(data: &[u8], shape: &[usize], dtype: crate::backend::DType) -> Self {
+        GgmlTensor {
+            data: data.to_vec(),
+            shape: shape.iter().map(|&s| s as i64).collect(),
+            kind: dtype.into(),
+        }
+    }
+
+    fn from_tensor_view(tv: &safetensors::tensor::TensorView<'_>) -> Self {
+        let shape = tv.shape().iter().map(|&s| s as i64).collect::<Vec<_>>();
+        let data = match tv.dtype() {
+            safetensors::tensor::Dtype::F32 => tv.data().to_vec(),
+            safetensors::tensor::Dtype::BF16 => {
+                // bf16 -> f32
+                let f32_data = tv
+                    .data()
+                    .chunks_exact(2)
+                    .flat_map(|chunk| {
+                        let bf16 = u16::from_le_bytes([chunk[0], chunk[1]]);
+                        f32::from_bits((bf16 as u32) << 16).to_le_bytes()
+                    })
+                    .collect();
+                f32_data
+            }
+            _ => unimplemented!(),
+        };
+        GgmlTensor {
+            data,
+            shape,
+            kind: Kind::F32,
+        }
+    }
+
+    fn device(&self) -> crate::backend::Device {
+        crate::backend::Device::CPU
+    }
+
+    fn to_device(&self, dev: crate::backend::Device) -> Self {
+        assert_eq!(dev, crate::backend::Device::CPU);
+        self.clone()
+    }
+}

--- a/ek-computation/src/backend/ggml/mod.rs
+++ b/ek-computation/src/backend/ggml/mod.rs
@@ -1,6 +1,11 @@
+mod ggml_safetensors;
+
 use ek_ggml::Kind;
 
-use crate::backend::{EkTensor, FromSafeTensor};
+use crate::backend::{
+    EkTensor, FromSafeTensor,
+    ggml::ggml_safetensors::{dtype_to_ggml_kind, write_safetensors},
+};
 
 impl From<crate::backend::DType> for Kind {
     fn from(value: crate::backend::DType) -> Self {
@@ -17,6 +22,7 @@ impl From<ek_ggml::Kind> for crate::backend::DType {
         match value {
             Kind::F32 => crate::backend::DType::Float,
             Kind::BF16 => crate::backend::DType::BFloat16,
+            _ => unimplemented!(),
         }
     }
 }
@@ -79,7 +85,7 @@ impl EkTensor for GgmlTensor {
     }
 
     fn serialize(&self) -> Vec<u8> {
-        self.data.clone()
+        write_safetensors(&[("data", self)]).unwrap()
     }
 
     fn from_raw(data: &[u8], shape: &[usize], dtype: crate::backend::DType) -> Self {
@@ -92,11 +98,7 @@ impl EkTensor for GgmlTensor {
 
     fn from_tensor_view(tv: &safetensors::tensor::TensorView<'_>) -> Self {
         let shape = tv.shape().iter().map(|&s| s as i64).collect::<Vec<_>>();
-        let kind = match tv.dtype() {
-            safetensors::tensor::Dtype::F32 => Kind::F32,
-            safetensors::tensor::Dtype::BF16 => Kind::BF16,
-            _ => unimplemented!(),
-        };
+        let kind = dtype_to_ggml_kind(tv.dtype()).unwrap();
         GgmlTensor {
             data: tv.data().to_vec(),
             shape,

--- a/ek-computation/src/backend/mod.rs
+++ b/ek-computation/src/backend/mod.rs
@@ -1,5 +1,6 @@
 use safetensors::tensor::TensorView;
 
+pub mod ggml;
 pub mod ort;
 pub mod torch;
 
@@ -14,7 +15,20 @@ pub enum DType {
     Float8e4m3fnuz,
 }
 
-#[derive(Clone, Copy, Debug)]
+impl DType {
+    pub fn size(&self) -> usize {
+        match self {
+            DType::Uint8 => 1,
+            DType::Int8 => 1,
+            DType::Int16 => 2,
+            DType::BFloat16 => 2,
+            DType::Float => 4,
+            DType::Float8e4m3fn | DType::Float8e4m3fnuz => 1, // Assuming these are packed formats
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Device {
     CPU,
     CUDA(usize),
@@ -45,7 +59,6 @@ impl From<&str> for Device {
 
 pub trait EkTensor: Sized {
     fn rand(shape: Vec<usize>, dtype: DType, dev: Device) -> Self;
-    fn stack(tensors: &[Self], dim: usize) -> Self;
     fn shape(&self) -> Vec<usize>;
     fn serialize(&self) -> Vec<u8>;
     fn from_raw(data: &[u8], shape: &[usize], dtype: DType) -> Self;

--- a/ek-computation/src/backend/ort/mod.rs
+++ b/ek-computation/src/backend/ort/mod.rs
@@ -67,15 +67,6 @@ where
         Self(res)
     }
 
-    fn stack(tensors: &[Self], dim: usize) -> Self {
-        let views = tensors.iter().map(|x| x.0.view()).collect::<Vec<_>>();
-        let res = ndarray::stack(ndarray::Axis(dim), &views)
-            .unwrap()
-            .into_dimensionality::<IxDyn>()
-            .unwrap();
-        NDArrayTensor(res)
-    }
-
     fn shape(&self) -> Vec<usize> {
         self.0.shape().to_vec()
     }

--- a/ek-computation/src/backend/torch/mod.rs
+++ b/ek-computation/src/backend/torch/mod.rs
@@ -117,10 +117,6 @@ impl EkTensor for TchTensor {
         TchTensor(rand)
     }
 
-    fn stack(tensors: &[Self], dim: usize) -> Self {
-        TchTensor(tch::Tensor::stack(tensors, dim as i64))
-    }
-
     fn shape(&self) -> Vec<usize> {
         self.0.size().iter().map(|&x| x as usize).collect()
     }

--- a/ek-computation/src/ffn/expert_ggml.rs
+++ b/ek-computation/src/ffn/expert_ggml.rs
@@ -7,7 +7,7 @@ use crate::{
     ffn::meta::{Expert, ExpertShape, ExpertWeight},
 };
 
-const MAX_BATCH_SIZE_LOG2: usize = 9;
+const MAX_BATCH_SIZE_LOG2: usize = 6;
 
 pub struct GgmlFFN {
     dim: usize,
@@ -24,11 +24,12 @@ impl GgmlFFN {
         n_threads: usize,
     ) -> Self {
         let mut context_size = 0;
-        context_size += weight.up_w.shape.iter().sum::<i64>() as usize * weight.up_w.kind.size();
         context_size +=
-            weight.down_w.shape.iter().sum::<i64>() as usize * weight.down_w.kind.size();
+            weight.up_w.shape.iter().product::<i64>() as usize * weight.up_w.kind.size();
         context_size +=
-            weight.gate_w.shape.iter().sum::<i64>() as usize * weight.gate_w.kind.size();
+            weight.down_w.shape.iter().product::<i64>() as usize * weight.down_w.kind.size();
+        context_size +=
+            weight.gate_w.shape.iter().product::<i64>() as usize * weight.gate_w.kind.size();
         context_size += 3 * Tensor::overhead();
 
         for i in 0..=MAX_BATCH_SIZE_LOG2 {
@@ -44,8 +45,10 @@ impl GgmlFFN {
             context_size += Graph::<1>::overhead(); // overhead for graph
             context_size += 1024; // additional overhead
         }
+        let context_size = context_size.next_multiple_of(4096);
+        let context = Context::new(context_size);
 
-        let context = Context::new(context_size.next_multiple_of(4096));
+        log::debug!("Created context with size {}", context_size);
         let weights = [
             context
                 .create_tensor(&weight.up_w.shape, weight.up_w.kind, weight.up_w.data)
@@ -127,24 +130,40 @@ impl GgmlForwardInner {
         let graph = self.compute[index].get_or_insert_with(|| {
             self.context.create_graph(|allocator| {
                 let [w1, w2, w3] = &self.weights;
+
+                let [w1, w2, w3] = [
+                    allocator.borrow(w1),
+                    allocator.borrow(w2),
+                    allocator.borrow(w3),
+                ];
+
                 let input = allocator.alloc(&[padded_batch_size as _, self.dim as _], Kind::BF16); // [B, N] x bf16
-                let up = input.matmul(allocator.borrow_shared(w1)); // [I, B] x f32
-                let gate = input.matmul(allocator.borrow_shared(w3)); // [I, B] x f32
+                let up = input.matmul(w1); // [I, B] x f32
+                let gate = input.matmul(w3); // [I, B] x f32
                 let hidden = up.mul_inplace(&gate.silu_inplace()).cast(input.kind()); // [I, B] x bf16
                 let hidden = hidden.transpose(); // [B, I] x bf16
-                let output = allocator.borrow_shared(w2).matmul(&hidden); // [B, N] x f32
+                let output = w2.matmul(&hidden); // [B, N] x f32
                 let output = output.cast(input.kind()); // [B, N] x bf16
+
                 ([input], output)
             })
         });
+
         if padded_batch_size > batch_size {
+            let [input_kind] = graph.inputs_kind();
+            let output_kind = graph.output_kind();
             let input = x
                 .iter()
                 .cloned()
                 .chain(std::iter::repeat(0u8))
-                .take(padded_batch_size * self.dim * graph.inputs_kind()[0].size())
+                .take(padded_batch_size * self.dim * input_kind.size())
                 .collect::<Vec<_>>();
-            graph.compute([&input], n_threads).unwrap()
+            graph
+                .compute([&input], n_threads)
+                .unwrap()
+                .into_iter()
+                .take(batch_size * self.dim * output_kind.size())
+                .collect::<Vec<_>>()
         } else {
             graph.compute([x], n_threads).unwrap()
         }
@@ -155,6 +174,7 @@ impl GgmlForwardInner {
 mod test {
     use std::fs;
 
+    use ek_ggml::Kind;
     use safetensors::SafeTensors;
 
     use crate::{
@@ -191,6 +211,7 @@ mod test {
         let tv = gt_st.tensor("1-input").unwrap();
 
         let inp = GgmlTensor::from_tensor_view(&tv);
+        assert_eq!(inp.kind, Kind::BF16);
 
         let inp_tch = TchTensor::from_tensor_view(&tv);
 
@@ -202,9 +223,12 @@ mod test {
             )
         };
         assert_eq!(inp_data.len(), inp_tch_data.len());
-        assert_eq!(inp_data[..20], inp_tch_data[..20]);
+        assert_eq!(inp_data, inp_tch_data);
 
         let res = ffn.forward(&inp);
+
+        assert_eq!(inp.data.len(), res.data.len());
+        assert_eq!(inp.shape, res.shape);
 
         let truth = TchTensor::from_tensor_view(&gt_st.tensor("1-output").unwrap()).inner();
 

--- a/ek-computation/src/ffn/expert_ggml.rs
+++ b/ek-computation/src/ffn/expert_ggml.rs
@@ -7,8 +7,14 @@ use crate::{
     ffn::meta::{Expert, ExpertShape, ExpertWeight},
 };
 
-const MAX_BATCH_SIZE_LOG2: usize = 6;
+const MAX_BATCH_SIZE_LOG2: usize = 8;
+const MAX_BATCH_SIZE: usize = 2_usize.pow(MAX_BATCH_SIZE_LOG2 as u32);
 
+/// GGML-based Feed Forward Network implementation with divide-and-conquer support for large batches.
+///
+/// This implementation supports batch sizes up to 2^MAX_BATCH_SIZE_LOG2 directly using pre-allocated
+/// computation graphs. For larger batch sizes, it automatically uses a divide-and-conquer algorithm
+/// to split the input into smaller chunks that can be processed individually and then concatenated.
 pub struct GgmlFFN {
     dim: usize,
     intermediate_dim: usize,
@@ -24,40 +30,44 @@ impl GgmlFFN {
         n_threads: usize,
     ) -> Self {
         let mut context_size = 0;
-        context_size +=
-            weight.up_w.shape.iter().product::<i64>() as usize * weight.up_w.kind.size();
-        context_size +=
-            weight.down_w.shape.iter().product::<i64>() as usize * weight.down_w.kind.size();
-        context_size +=
-            weight.gate_w.shape.iter().product::<i64>() as usize * weight.gate_w.kind.size();
         context_size += 3 * Tensor::overhead();
+        log::debug!("Context size after initial overhead: {}", context_size);
 
         for i in 0..=MAX_BATCH_SIZE_LOG2 {
-            let batch_size = 2_usize.pow(i as _);
-            context_size += batch_size * dim * Kind::BF16.size(); // input 
-            context_size += batch_size * intermediate_dim * Kind::F32.size(); // up
-            context_size += batch_size * intermediate_dim * Kind::F32.size(); // gate
-            context_size += batch_size * intermediate_dim * Kind::BF16.size(); // hidden
-            context_size += batch_size * intermediate_dim * Kind::BF16.size(); // hidden.T
-            context_size += batch_size * dim * Kind::F32.size(); // output
-            context_size += batch_size * dim * Kind::BF16.size(); // output.cast
-            context_size += 7 * Tensor::overhead(); // overhead for tensors
-            context_size += Graph::<1>::overhead(); // overhead for graph
-            context_size += 1024; // additional overhead
+            let mut overhead = 0;
+            overhead += 7 * Tensor::overhead(); // overhead for tensors
+            overhead += Tensor::overhead() * Graph::<1>::default_size() + Graph::<1>::overhead(); // overhead for graph
+            log::debug!(
+                "Adding overhead for batch size 2^{}, overhead: {}",
+                i,
+                overhead
+            );
+            context_size += overhead;
         }
-        let context_size = context_size.next_multiple_of(4096);
         let context = Context::new(context_size);
 
         log::debug!("Created context with size {}", context_size);
         let weights = [
             context
-                .create_tensor(&weight.up_w.shape, weight.up_w.kind, weight.up_w.data)
+                .create_tensor(
+                    &weight.up_w.shape,
+                    weight.up_w.kind,
+                    weight.up_w.data.into_boxed_slice(),
+                )
                 .unwrap(),
             context
-                .create_tensor(&weight.down_w.shape, weight.down_w.kind, weight.down_w.data)
+                .create_tensor(
+                    &weight.down_w.shape,
+                    weight.down_w.kind,
+                    weight.down_w.data.into_boxed_slice(),
+                )
                 .unwrap(),
             context
-                .create_tensor(&weight.gate_w.shape, weight.gate_w.kind, weight.gate_w.data)
+                .create_tensor(
+                    &weight.gate_w.shape,
+                    weight.gate_w.kind,
+                    weight.gate_w.data.into_boxed_slice(),
+                )
                 .unwrap(),
         ];
         Self {
@@ -107,6 +117,9 @@ impl Expert<GgmlTensor> for GgmlFFN {
     }
 }
 
+unsafe impl Send for GgmlFFN {}
+unsafe impl Sync for GgmlFFN {}
+
 struct GgmlForwardInner {
     dim: usize,
     context: Context,
@@ -115,38 +128,43 @@ struct GgmlForwardInner {
 }
 
 impl GgmlForwardInner {
+    /// Forward pass with automatic large batch handling.
+    ///
+    /// For batch sizes <= 2^MAX_BATCH_SIZE_LOG2, uses pre-allocated computation graphs.
+    /// For larger batch sizes, automatically switches to divide-and-conquer algorithm.
     fn forward(&mut self, shape: &[usize], x: &[u8], n_threads: usize) -> Vec<u8> {
         let batch_size = shape[0];
         let padded_batch_size = batch_size.next_power_of_two();
-
         let index = padded_batch_size.ilog2() as usize;
 
-        assert!(
-            index <= MAX_BATCH_SIZE_LOG2,
-            "Batch size too large: {}",
-            padded_batch_size
-        );
+        // If batch size exceeds the maximum supported size, use divide-and-conquer algorithm
+        if index > MAX_BATCH_SIZE_LOG2 {
+            return self.forward_divide_and_conquer(shape, x, n_threads);
+        }
 
         let graph = self.compute[index].get_or_insert_with(|| {
-            self.context.create_graph(|allocator| {
-                let [w1, w2, w3] = &self.weights;
+            self.context
+                .create_graph(|allocator| {
+                    let [w1, w2, w3] = &self.weights;
 
-                let [w1, w2, w3] = [
-                    allocator.borrow(w1),
-                    allocator.borrow(w2),
-                    allocator.borrow(w3),
-                ];
+                    let [w1, w2, w3] = [
+                        allocator.borrow(w1),
+                        allocator.borrow(w2),
+                        allocator.borrow(w3),
+                    ];
 
-                let input = allocator.alloc(&[padded_batch_size as _, self.dim as _], Kind::BF16); // [B, N] x bf16
-                let up = input.matmul(w1); // [I, B] x f32
-                let gate = input.matmul(w3); // [I, B] x f32
-                let hidden = up.mul_inplace(&gate.silu_inplace()).cast(input.kind()); // [I, B] x bf16
-                let hidden = hidden.transpose(); // [B, I] x bf16
-                let output = w2.matmul(&hidden); // [B, N] x f32
-                let output = output.cast(input.kind()); // [B, N] x bf16
+                    let input =
+                        allocator.alloc(&[padded_batch_size as _, self.dim as _], Kind::BF16); // [B, N] x bf16
+                    let up = input.matmul(&w1); // [I, B] x f32
+                    let gate = input.matmul(&w3); // [I, B] x f32
+                    let hidden = up.mul_inplace(&gate.silu_inplace()?)?.cast(input.kind()); // [I, B] x bf16
+                    let hidden = hidden.transpose(); // [B, I] x bf16
+                    let output = w2.matmul(&hidden); // [B, N] x f32
+                    let output = output.cast(input.kind()); // [B, N] x bf16
 
-                ([input], output)
-            })
+                    Ok(([input], output))
+                })
+                .unwrap()
         });
 
         if padded_batch_size > batch_size {
@@ -167,6 +185,57 @@ impl GgmlForwardInner {
         } else {
             graph.compute([x], n_threads).unwrap()
         }
+    }
+
+    /// Process large batch sizes using divide-and-conquer algorithm.
+    ///
+    /// This method splits large batches into multiple smaller batches that don't exceed
+    /// 2^MAX_BATCH_SIZE_LOG2, processes them separately, and then concatenates the results.
+    /// This allows efficient processing of arbitrarily large batches without failing due
+    /// to memory or computation graph size constraints.
+    ///
+    /// # Algorithm Flow
+    /// 1. Calculate maximum supported batch size (2^MAX_BATCH_SIZE_LOG2)
+    /// 2. Split input data according to maximum batch size
+    /// 3. Recursively call forward method on each sub-batch
+    /// 4. Concatenate all sub-batch results into final result
+    fn forward_divide_and_conquer(
+        &mut self,
+        shape: &[usize],
+        x: &[u8],
+        n_threads: usize,
+    ) -> Vec<u8> {
+        let batch_size = shape[0];
+
+        // If batch size is less than or equal to maximum supported size, call original forward directly
+        if batch_size <= MAX_BATCH_SIZE {
+            return self.forward(shape, x, n_threads);
+        }
+
+        let input_size_per_sample = self.dim * Kind::BF16.size();
+
+        let mut results = Vec::new();
+        let mut processed = 0;
+
+        while processed < batch_size {
+            let current_batch_size = std::cmp::min(MAX_BATCH_SIZE, batch_size - processed);
+
+            // Extract current batch data
+            let start_idx = processed * input_size_per_sample;
+            let end_idx = (processed + current_batch_size) * input_size_per_sample;
+            let current_input = &x[start_idx..end_idx];
+
+            // Recursively process current batch
+            let current_shape = [current_batch_size, shape[1]];
+            let current_output = self.forward(&current_shape, current_input, n_threads);
+
+            // Collect results
+            results.extend_from_slice(&current_output);
+
+            processed += current_batch_size;
+        }
+
+        results
     }
 }
 
@@ -234,7 +303,45 @@ mod test {
 
         let res_tch = TchTensor::from_raw(&res.data, &res.shape(), res.kind.into()).inner();
 
-        let diff = (&res_tch - &truth).sum(tch::Kind::BFloat16);
+        let diff = (&res_tch - &truth).abs().sum(tch::Kind::BFloat16);
         diff.print();
+    }
+
+    #[test]
+    fn test_ggml_large_batch_divide_and_conquer() {
+        let st_fp = test_root()
+            .join("resources")
+            .join("qwen3-l0e1.weight.safetensors");
+        let st_bytes = fs::read(st_fp).unwrap();
+        let st = SafeTensors::deserialize(&st_bytes).unwrap();
+        let weight = ExpertWeight::from_safetensor(&st, Device::CPU).unwrap();
+        let inst = x::EKInstance {
+            hidden: 2048,
+            intermediate: 768,
+            backend: x::ExpertBackendType::Ggml,
+            device: Device::CPU,
+        };
+        let ffn = GgmlFFN::construct(inst, weight).unwrap();
+
+        // Test batch size exceeding MAX_BATCH_SIZE_LOG2
+        let large_batch_size = 2_usize.pow((super::MAX_BATCH_SIZE_LOG2 + 2) as u32); // 4 times larger than maximum supported size
+        let large_input = ffn.rand_input(large_batch_size);
+
+        // This call should trigger divide-and-conquer algorithm instead of panic
+        let result = ffn.forward(&large_input);
+
+        // Verify result shape and type
+        assert_eq!(result.shape[0], large_batch_size as i64);
+        assert_eq!(result.shape[1], 2048);
+        assert_eq!(result.kind, Kind::BF16);
+
+        // Verify result data length is correct
+        let expected_data_len = large_batch_size * 2048 * Kind::BF16.size();
+        assert_eq!(result.data.len(), expected_data_len);
+
+        println!(
+            "Successfully processed large batch of size {} using divide-and-conquer",
+            large_batch_size
+        );
     }
 }

--- a/ek-computation/src/ffn/expert_ggml.rs
+++ b/ek-computation/src/ffn/expert_ggml.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Mutex};
 
-use ek_ggml::{Graph, Kind, Tensor};
+use ek_ggml::{Context, Graph, Kind, Tensor};
 
 use crate::{
     backend::{DType, Device, EkTensor, ggml::GgmlTensor},
@@ -10,8 +10,7 @@ use crate::{
 pub struct GgmlFFN {
     dim: usize,
     intermediate_dim: usize,
-    weight: ExpertWeight<GgmlTensor>,
-    io: Mutex<HashMap<u32, (Tensor, Graph, Tensor)>>,
+    inner: Mutex<GgmlForwardInner>,
     n_threads: usize,
 }
 
@@ -22,11 +21,46 @@ impl GgmlFFN {
         weight: ExpertWeight<GgmlTensor>,
         n_threads: usize,
     ) -> Self {
+        let mut context_size = 0;
+        context_size += weight.up_w.shape.iter().sum::<i64>() as usize * weight.up_w.kind.size();
+        context_size +=
+            weight.down_w.shape.iter().sum::<i64>() as usize * weight.down_w.kind.size();
+        context_size +=
+            weight.gate_w.shape.iter().sum::<i64>() as usize * weight.gate_w.kind.size();
+        context_size += 3 * Tensor::overhead();
+
+        for i in 0..=9 {
+            let batch_size = 2_usize.pow(i);
+            context_size += batch_size * dim * Kind::BF16.size(); // input 
+            context_size += batch_size * intermediate_dim * Kind::F32.size(); // up
+            context_size += batch_size * intermediate_dim * Kind::F32.size(); // gate
+            context_size += batch_size * intermediate_dim * Kind::BF16.size(); // hidden
+            context_size += batch_size * intermediate_dim * Kind::BF16.size(); // hidden.T
+            context_size += batch_size * dim * Kind::F32.size(); // output
+            context_size += batch_size * dim * Kind::BF16.size(); // output.cast
+            context_size += 7 * Tensor::overhead(); // overhead for tensors
+            context_size += Graph::overhead(); // overhead for graph
+            context_size += 1024; // additional overhead
+        }
+
+        let mut context = Context::new(context_size.next_multiple_of(4096));
+        let mut weights = [
+            context.create_tensor(&weight.up_w.shape, weight.up_w.kind),
+            context.create_tensor(&weight.down_w.shape, weight.down_w.kind),
+            context.create_tensor(&weight.gate_w.shape, weight.gate_w.kind),
+        ];
+        weights[0].set_data(&weight.up_w.data).unwrap();
+        weights[1].set_data(&weight.down_w.data).unwrap();
+        weights[2].set_data(&weight.gate_w.data).unwrap();
         Self {
             dim,
             intermediate_dim,
-            weight,
-            io: Mutex::new(HashMap::new()),
+            inner: Mutex::new(GgmlForwardInner {
+                dim,
+                context,
+                weights,
+                compute: HashMap::default(),
+            }),
             n_threads,
         }
     }
@@ -34,93 +68,16 @@ impl GgmlFFN {
 
 impl Expert<GgmlTensor> for GgmlFFN {
     fn forward(&self, x: &GgmlTensor) -> GgmlTensor {
-        let shape = x.shape(); // [B, N]
-        let batch_size = shape[0];
-        let padded_batch_size = batch_size.next_power_of_two();
-        let log2 = padded_batch_size.ilog2();
-
-        let mut io = self.io.lock().unwrap();
-        let (input, graph, output) = io.entry(log2).or_insert_with(|| {
-            let w1 = unsafe {
-                Tensor::from_raw(
-                    &self.weight.up_w.data,
-                    &self.weight.up_w.shape,
-                    self.weight.up_w.kind,
-                )
-                .unwrap()
-            }; // [I, N]
-
-            let w2 = unsafe {
-                Tensor::from_raw(
-                    &self.weight.down_w.data,
-                    &self.weight.down_w.shape,
-                    self.weight.down_w.kind,
-                )
-                .unwrap()
-            }; // [N, I]
-
-            let w3 = unsafe {
-                Tensor::from_raw(
-                    &self.weight.gate_w.data,
-                    &self.weight.gate_w.shape,
-                    self.weight.gate_w.kind,
-                )
-                .unwrap()
-            }; // [I, N]
-
-            let input =
-                Tensor::empty(&vec![padded_batch_size as _, self.dim as _], Kind::F32).unwrap(); // [B, N]
-
-            let up = input.matmul(&w1); // [B, I]
-            let gate = input.matmul(&w3); // [B, I]
-
-            let hidden = up.mul(&gate.silu()); // [B, I]
-            let output = hidden.transpose().matmul(&w2).transpose(); // [B, N]
-
-            let mut graph = Graph::new();
-            graph.build_forward(&output);
-
-            (input, graph, output)
-        });
-
-        if padded_batch_size > batch_size {
-            input
-                .set_data(
-                    &x.data
-                        .iter()
-                        .cloned()
-                        .chain(std::iter::repeat(0u8))
-                        .take(padded_batch_size * self.dim * input.kind().size())
-                        .collect::<Vec<_>>()
-                        .as_ref(),
-                )
-                .unwrap();
-            graph.compute(self.n_threads);
-
-            GgmlTensor {
-                data: output
-                    .raw_data()
-                    .iter()
-                    .cloned()
-                    .take(batch_size * self.dim * output.kind().size())
-                    .collect(),
-                kind: output.kind(),
-                shape: x.shape.clone(),
-            }
-        } else {
-            input.set_data(&x.data).unwrap();
-            graph.compute(self.n_threads);
-
-            GgmlTensor {
-                data: output.raw_data().to_vec(),
-                kind: output.kind(),
-                shape: output.shape(),
-            }
+        let mut inner = self.inner.lock().unwrap();
+        GgmlTensor {
+            data: inner.forward(&x.shape(), &x.data, self.n_threads),
+            shape: x.shape.clone(),
+            kind: x.kind,
         }
     }
 
     fn rand_input(&self, batch: usize) -> GgmlTensor {
-        GgmlTensor::rand(vec![batch, self.dim], DType::Float, Device::CPU)
+        GgmlTensor::rand(vec![batch, self.dim], DType::BFloat16, Device::CPU)
     }
 
     fn shape(&self) -> super::meta::ExpertShape {
@@ -138,17 +95,67 @@ impl Expert<GgmlTensor> for GgmlFFN {
         x: crate::x::EKInstance,
         weight: ExpertWeight<GgmlTensor>,
     ) -> ek_base::error::EKResult<Self> {
-        Ok(Self::new(x.hidden, x.intermediate, weight, 16)) // TODO: Make n_threads configurable
+        Ok(Self::new(x.hidden, x.intermediate, weight, 8)) // TODO: Make n_threads configurable
     }
 }
 
-unsafe impl Sync for GgmlFFN {}
+struct GgmlForwardInner {
+    dim: usize,
+    context: Context,
+    weights: [Tensor; 3],
+    compute: HashMap<usize, (Tensor, Graph, Tensor)>,
+}
+
+impl GgmlForwardInner {
+    fn forward(&mut self, shape: &[usize], x: &[u8], n_threads: usize) -> Vec<u8> {
+        let batch_size = shape[0];
+        let padded_batch_size = batch_size.next_power_of_two();
+        let (input, graph, output) = self.compute.entry(padded_batch_size).or_insert_with(|| {
+            let [w1, w2, w3] = &self.weights;
+            let input = self
+                .context
+                .create_tensor(&[padded_batch_size as _, self.dim as _], Kind::BF16); // [B, N] x bf16
+            let up = input.matmul(&w1); // [I, B] x f32
+            let gate = input.matmul(&w3); // [I, B] x f32
+            let hidden = up.mul_inplace(&gate.silu_inplace()).cast(input.kind()); // [I, B] x bf16
+            let hidden = hidden.transpose(); // [B, I] x bf16
+            let output = w2.matmul(&hidden); // [B, N] x f32
+            let output = output.cast(input.kind()); // [B, N] x bf16
+            let mut graph = self.context.create_graph();
+            graph.build_forward(&output);
+            (input, graph, output)
+        });
+        if padded_batch_size > batch_size {
+            input
+                .set_data(
+                    &x.iter()
+                        .cloned()
+                        .chain(std::iter::repeat(0u8))
+                        .take(padded_batch_size * self.dim * input.kind().size())
+                        .collect::<Vec<_>>(),
+                )
+                .unwrap();
+        } else {
+            input.set_data(&x).unwrap();
+        }
+        graph.compute(n_threads);
+        if padded_batch_size > batch_size {
+            output
+                .get_data()
+                .iter()
+                .cloned()
+                .take(batch_size * self.dim * output.kind().size())
+                .collect()
+        } else {
+            output.get_data().iter().cloned().collect()
+        }
+    }
+}
 
 #[cfg(test)]
 mod test {
     use std::fs;
 
-    use ek_ggml::Context;
     use safetensors::SafeTensors;
 
     use crate::{
@@ -162,8 +169,6 @@ mod test {
 
     #[test]
     fn test_ggml_correctness() {
-        Context::init(1024 * 1024 * 1024);
-
         let st_fp = test_root()
             .join("resources")
             .join("qwen3-l0e1.weight.safetensors");
@@ -188,11 +193,7 @@ mod test {
 
         let inp = GgmlTensor::from_tensor_view(&tv);
 
-        let inp_tch = TchTensor(
-            TchTensor::from_tensor_view(&tv)
-                .inner()
-                .to_kind(tch::Kind::Float),
-        );
+        let inp_tch = TchTensor::from_tensor_view(&tv);
 
         let inp_data = inp.data.as_slice();
         let inp_tch_data = unsafe {
@@ -206,13 +207,11 @@ mod test {
 
         let res = ffn.forward(&inp);
 
-        let truth = TchTensor::from_tensor_view(&gt_st.tensor("1-output").unwrap())
-            .inner()
-            .to_kind(tch::Kind::Float);
+        let truth = TchTensor::from_tensor_view(&gt_st.tensor("1-output").unwrap()).inner();
 
         let res_tch = TchTensor::from_raw(&res.data, &res.shape(), res.kind.into()).inner();
 
-        let diff = (&res_tch - &truth).sum(tch::Kind::Float);
+        let diff = (&res_tch - &truth).sum(tch::Kind::BFloat16);
         diff.print();
     }
 }

--- a/ek-computation/src/ffn/expert_ggml.rs
+++ b/ek-computation/src/ffn/expert_ggml.rs
@@ -115,8 +115,8 @@ impl GgmlForwardInner {
             let input = self
                 .context
                 .create_tensor(&[padded_batch_size as _, self.dim as _], Kind::BF16); // [B, N] x bf16
-            let up = input.matmul(&w1); // [I, B] x f32
-            let gate = input.matmul(&w3); // [I, B] x f32
+            let up = input.matmul(w1); // [I, B] x f32
+            let gate = input.matmul(w3); // [I, B] x f32
             let hidden = up.mul_inplace(&gate.silu_inplace()).cast(input.kind()); // [I, B] x bf16
             let hidden = hidden.transpose(); // [B, I] x bf16
             let output = w2.matmul(&hidden); // [B, N] x f32
@@ -136,7 +136,7 @@ impl GgmlForwardInner {
                 )
                 .unwrap();
         } else {
-            input.set_data(&x).unwrap();
+            input.set_data(x).unwrap();
         }
         graph.compute(n_threads);
         if padded_batch_size > batch_size {
@@ -147,7 +147,7 @@ impl GgmlForwardInner {
                 .take(batch_size * self.dim * output.kind().size())
                 .collect()
         } else {
-            output.get_data().iter().cloned().collect()
+            output.get_data().to_vec()
         }
     }
 }

--- a/ek-computation/src/ffn/expert_ggml.rs
+++ b/ek-computation/src/ffn/expert_ggml.rs
@@ -1,0 +1,218 @@
+use std::{collections::HashMap, sync::Mutex};
+
+use ek_ggml::{Graph, Kind, Tensor};
+
+use crate::{
+    backend::{DType, Device, EkTensor, ggml::GgmlTensor},
+    ffn::meta::{Expert, ExpertShape, ExpertWeight},
+};
+
+pub struct GgmlFFN {
+    dim: usize,
+    intermediate_dim: usize,
+    weight: ExpertWeight<GgmlTensor>,
+    io: Mutex<HashMap<u32, (Tensor, Graph, Tensor)>>,
+    n_threads: usize,
+}
+
+impl GgmlFFN {
+    pub fn new(
+        dim: usize,
+        intermediate_dim: usize,
+        weight: ExpertWeight<GgmlTensor>,
+        n_threads: usize,
+    ) -> Self {
+        Self {
+            dim,
+            intermediate_dim,
+            weight,
+            io: Mutex::new(HashMap::new()),
+            n_threads,
+        }
+    }
+}
+
+impl Expert<GgmlTensor> for GgmlFFN {
+    fn forward(&self, x: &GgmlTensor) -> GgmlTensor {
+        let shape = x.shape(); // [B, N]
+        let batch_size = shape[0];
+        let padded_batch_size = batch_size.next_power_of_two();
+        let log2 = padded_batch_size.ilog2();
+
+        let mut io = self.io.lock().unwrap();
+        let (input, graph, output) = io.entry(log2).or_insert_with(|| {
+            let w1 = unsafe {
+                Tensor::from_raw(
+                    &self.weight.up_w.data,
+                    &self.weight.up_w.shape,
+                    self.weight.up_w.kind,
+                )
+                .unwrap()
+            }; // [I, N]
+
+            let w2 = unsafe {
+                Tensor::from_raw(
+                    &self.weight.down_w.data,
+                    &self.weight.down_w.shape,
+                    self.weight.down_w.kind,
+                )
+                .unwrap()
+            }; // [N, I]
+
+            let w3 = unsafe {
+                Tensor::from_raw(
+                    &self.weight.gate_w.data,
+                    &self.weight.gate_w.shape,
+                    self.weight.gate_w.kind,
+                )
+                .unwrap()
+            }; // [I, N]
+
+            let input =
+                Tensor::empty(&vec![padded_batch_size as _, self.dim as _], Kind::F32).unwrap(); // [B, N]
+
+            let up = input.matmul(&w1); // [B, I]
+            let gate = input.matmul(&w3); // [B, I]
+
+            let hidden = up.mul(&gate.silu()); // [B, I]
+            let output = hidden.transpose().matmul(&w2).transpose(); // [B, N]
+
+            let mut graph = Graph::new();
+            graph.build_forward(&output);
+
+            (input, graph, output)
+        });
+
+        if padded_batch_size > batch_size {
+            input
+                .set_data(
+                    &x.data
+                        .iter()
+                        .cloned()
+                        .chain(std::iter::repeat(0u8))
+                        .take(padded_batch_size * self.dim * input.kind().size())
+                        .collect::<Vec<_>>()
+                        .as_ref(),
+                )
+                .unwrap();
+            graph.compute(self.n_threads);
+
+            GgmlTensor {
+                data: output
+                    .raw_data()
+                    .iter()
+                    .cloned()
+                    .take(batch_size * self.dim * output.kind().size())
+                    .collect(),
+                kind: output.kind(),
+                shape: x.shape.clone(),
+            }
+        } else {
+            input.set_data(&x.data).unwrap();
+            graph.compute(self.n_threads);
+
+            GgmlTensor {
+                data: output.raw_data().to_vec(),
+                kind: output.kind(),
+                shape: output.shape(),
+            }
+        }
+    }
+
+    fn rand_input(&self, batch: usize) -> GgmlTensor {
+        GgmlTensor::rand(vec![batch, self.dim], DType::Float, Device::CPU)
+    }
+
+    fn shape(&self) -> super::meta::ExpertShape {
+        ExpertShape {
+            hidden: self.dim,
+            intermediate: self.intermediate_dim,
+        }
+    }
+
+    fn backend(&self) -> std::string::String {
+        "ggml".to_string()
+    }
+
+    fn construct(
+        x: crate::x::EKInstance,
+        weight: ExpertWeight<GgmlTensor>,
+    ) -> ek_base::error::EKResult<Self> {
+        Ok(Self::new(x.hidden, x.intermediate, weight, 16)) // TODO: Make n_threads configurable
+    }
+}
+
+unsafe impl Sync for GgmlFFN {}
+
+#[cfg(test)]
+mod test {
+    use std::fs;
+
+    use ek_ggml::Context;
+    use safetensors::SafeTensors;
+
+    use crate::{
+        backend::{Device, EkTensor, ggml::GgmlTensor, torch::TchTensor},
+        ffn::{
+            expert_ggml::GgmlFFN,
+            meta::{Expert, ExpertWeight},
+        },
+        x::{self, test_root},
+    };
+
+    #[test]
+    fn test_ggml_correctness() {
+        Context::init(1024 * 1024 * 1024);
+
+        let st_fp = test_root()
+            .join("resources")
+            .join("qwen3-l0e1.weight.safetensors");
+        let st_bytes = fs::read(st_fp).unwrap();
+        let st = SafeTensors::deserialize(&st_bytes).unwrap();
+        let weight = ExpertWeight::from_safetensor(&st, Device::CPU).unwrap();
+        let inst = x::EKInstance {
+            hidden: 2048,
+            intermediate: 768,
+            backend: x::ExpertBackendType::Ggml,
+            device: Device::CPU,
+        };
+        let ffn = GgmlFFN::construct(inst, weight).unwrap();
+
+        let ground_truth_fp = test_root()
+            .join("resources")
+            .join("qwen3-l0e1.result.safetensors");
+        let ground_truth_bytes = fs::read(ground_truth_fp).unwrap();
+        let gt_st = SafeTensors::deserialize(&ground_truth_bytes).unwrap();
+
+        let tv = gt_st.tensor("1-input").unwrap();
+
+        let inp = GgmlTensor::from_tensor_view(&tv);
+
+        let inp_tch = TchTensor(
+            TchTensor::from_tensor_view(&tv)
+                .inner()
+                .to_kind(tch::Kind::Float),
+        );
+
+        let inp_data = inp.data.as_slice();
+        let inp_tch_data = unsafe {
+            std::slice::from_raw_parts(
+                inp_tch.inner().data_ptr() as *const u8,
+                inp_tch.inner().numel() * inp_tch.inner().kind().elt_size_in_bytes(),
+            )
+        };
+        assert_eq!(inp_data.len(), inp_tch_data.len());
+        assert_eq!(inp_data[..20], inp_tch_data[..20]);
+
+        let res = ffn.forward(&inp);
+
+        let truth = TchTensor::from_tensor_view(&gt_st.tensor("1-output").unwrap())
+            .inner()
+            .to_kind(tch::Kind::Float);
+
+        let res_tch = TchTensor::from_raw(&res.data, &res.shape(), res.kind.into()).inner();
+
+        let diff = (&res_tch - &truth).sum(tch::Kind::Float);
+        diff.print();
+    }
+}

--- a/ek-computation/src/ffn/expert_ggml.rs
+++ b/ek-computation/src/ffn/expert_ggml.rs
@@ -1,11 +1,13 @@
-use std::{collections::HashMap, sync::Mutex};
+use std::sync::Mutex;
 
-use ek_ggml::{Context, Graph, Kind, Tensor};
+use ek_ggml::{Context, Graph, Kind, SharedTensor, Tensor};
 
 use crate::{
     backend::{DType, Device, EkTensor, ggml::GgmlTensor},
     ffn::meta::{Expert, ExpertShape, ExpertWeight},
 };
+
+const MAX_BATCH_SIZE_LOG2: usize = 9;
 
 pub struct GgmlFFN {
     dim: usize,
@@ -29,8 +31,8 @@ impl GgmlFFN {
             weight.gate_w.shape.iter().sum::<i64>() as usize * weight.gate_w.kind.size();
         context_size += 3 * Tensor::overhead();
 
-        for i in 0..=9 {
-            let batch_size = 2_usize.pow(i);
+        for i in 0..=MAX_BATCH_SIZE_LOG2 {
+            let batch_size = 2_usize.pow(i as _);
             context_size += batch_size * dim * Kind::BF16.size(); // input 
             context_size += batch_size * intermediate_dim * Kind::F32.size(); // up
             context_size += batch_size * intermediate_dim * Kind::F32.size(); // gate
@@ -39,19 +41,22 @@ impl GgmlFFN {
             context_size += batch_size * dim * Kind::F32.size(); // output
             context_size += batch_size * dim * Kind::BF16.size(); // output.cast
             context_size += 7 * Tensor::overhead(); // overhead for tensors
-            context_size += Graph::overhead(); // overhead for graph
+            context_size += Graph::<1>::overhead(); // overhead for graph
             context_size += 1024; // additional overhead
         }
 
-        let mut context = Context::new(context_size.next_multiple_of(4096));
-        let mut weights = [
-            context.create_tensor(&weight.up_w.shape, weight.up_w.kind),
-            context.create_tensor(&weight.down_w.shape, weight.down_w.kind),
-            context.create_tensor(&weight.gate_w.shape, weight.gate_w.kind),
+        let context = Context::new(context_size.next_multiple_of(4096));
+        let weights = [
+            context
+                .create_tensor(&weight.up_w.shape, weight.up_w.kind, weight.up_w.data)
+                .unwrap(),
+            context
+                .create_tensor(&weight.down_w.shape, weight.down_w.kind, weight.down_w.data)
+                .unwrap(),
+            context
+                .create_tensor(&weight.gate_w.shape, weight.gate_w.kind, weight.gate_w.data)
+                .unwrap(),
         ];
-        weights[0].set_data(&weight.up_w.data).unwrap();
-        weights[1].set_data(&weight.down_w.data).unwrap();
-        weights[2].set_data(&weight.gate_w.data).unwrap();
         Self {
             dim,
             intermediate_dim,
@@ -59,7 +64,7 @@ impl GgmlFFN {
                 dim,
                 context,
                 weights,
-                compute: HashMap::default(),
+                compute: Box::new([const { None }; MAX_BATCH_SIZE_LOG2 + 1]),
             }),
             n_threads,
         }
@@ -102,52 +107,46 @@ impl Expert<GgmlTensor> for GgmlFFN {
 struct GgmlForwardInner {
     dim: usize,
     context: Context,
-    weights: [Tensor; 3],
-    compute: HashMap<usize, (Tensor, Graph, Tensor)>,
+    weights: [SharedTensor; 3],
+    compute: Box<[Option<Graph<1>>; MAX_BATCH_SIZE_LOG2 + 1]>,
 }
 
 impl GgmlForwardInner {
     fn forward(&mut self, shape: &[usize], x: &[u8], n_threads: usize) -> Vec<u8> {
         let batch_size = shape[0];
         let padded_batch_size = batch_size.next_power_of_two();
-        let (input, graph, output) = self.compute.entry(padded_batch_size).or_insert_with(|| {
-            let [w1, w2, w3] = &self.weights;
-            let input = self
-                .context
-                .create_tensor(&[padded_batch_size as _, self.dim as _], Kind::BF16); // [B, N] x bf16
-            let up = input.matmul(w1); // [I, B] x f32
-            let gate = input.matmul(w3); // [I, B] x f32
-            let hidden = up.mul_inplace(&gate.silu_inplace()).cast(input.kind()); // [I, B] x bf16
-            let hidden = hidden.transpose(); // [B, I] x bf16
-            let output = w2.matmul(&hidden); // [B, N] x f32
-            let output = output.cast(input.kind()); // [B, N] x bf16
-            let mut graph = self.context.create_graph();
-            graph.build_forward(&output);
-            (input, graph, output)
+
+        let index = padded_batch_size.ilog2() as usize;
+
+        assert!(
+            index <= MAX_BATCH_SIZE_LOG2,
+            "Batch size too large: {}",
+            padded_batch_size
+        );
+
+        let graph = self.compute[index].get_or_insert_with(|| {
+            self.context.create_graph(|allocator| {
+                let [w1, w2, w3] = &self.weights;
+                let input = allocator.alloc(&[padded_batch_size as _, self.dim as _], Kind::BF16); // [B, N] x bf16
+                let up = input.matmul(allocator.borrow_shared(w1)); // [I, B] x f32
+                let gate = input.matmul(allocator.borrow_shared(w3)); // [I, B] x f32
+                let hidden = up.mul_inplace(&gate.silu_inplace()).cast(input.kind()); // [I, B] x bf16
+                let hidden = hidden.transpose(); // [B, I] x bf16
+                let output = allocator.borrow_shared(w2).matmul(&hidden); // [B, N] x f32
+                let output = output.cast(input.kind()); // [B, N] x bf16
+                ([input], output)
+            })
         });
         if padded_batch_size > batch_size {
-            input
-                .set_data(
-                    &x.iter()
-                        .cloned()
-                        .chain(std::iter::repeat(0u8))
-                        .take(padded_batch_size * self.dim * input.kind().size())
-                        .collect::<Vec<_>>(),
-                )
-                .unwrap();
-        } else {
-            input.set_data(x).unwrap();
-        }
-        graph.compute(n_threads);
-        if padded_batch_size > batch_size {
-            output
-                .get_data()
+            let input = x
                 .iter()
                 .cloned()
-                .take(batch_size * self.dim * output.kind().size())
-                .collect()
+                .chain(std::iter::repeat(0u8))
+                .take(padded_batch_size * self.dim * graph.inputs_kind()[0].size())
+                .collect::<Vec<_>>();
+            graph.compute([&input], n_threads).unwrap()
         } else {
-            output.get_data().to_vec()
+            graph.compute([x], n_threads).unwrap()
         }
     }
 }

--- a/ek-computation/src/ffn/expert_ggml.rs
+++ b/ek-computation/src/ffn/expert_ggml.rs
@@ -113,7 +113,7 @@ impl Expert<GgmlTensor> for GgmlFFN {
         x: crate::x::EKInstance,
         weight: ExpertWeight<GgmlTensor>,
     ) -> ek_base::error::EKResult<Self> {
-        Ok(Self::new(x.hidden, x.intermediate, weight, 8)) // TODO: Make n_threads configurable
+        Ok(Self::new(x.hidden, x.intermediate, weight, 1)) // TODO: Make n_threads configurable
     }
 }
 

--- a/ek-computation/src/ffn/mod.rs
+++ b/ek-computation/src/ffn/mod.rs
@@ -34,7 +34,8 @@ impl ExpertBackend {
                 ExpertBackend::Torch(TorchFFN::construct(instance, weight)?)
             }
             x::ExpertBackendType::Ggml => {
-                let weight = ExpertWeight::<GgmlTensor>::from_safetensor(tensor, instance.device)?;
+                let weight: ExpertWeight<GgmlTensor> =
+                    ExpertWeight::<GgmlTensor>::from_safetensor(tensor, instance.device)?;
                 ExpertBackend::Ggml(expert_ggml::GgmlFFN::construct(instance, weight)?)
             }
             x::ExpertBackendType::Onnx => todo!(),

--- a/ek-computation/src/ffn/mod.rs
+++ b/ek-computation/src/ffn/mod.rs
@@ -6,10 +6,12 @@ use safetensors::tensor::TensorView;
 use tracing::instrument;
 
 use crate::{
-    backend::{EkTensor, torch::TchTensor},
+    backend::{EkTensor, ggml::GgmlTensor, torch::TchTensor},
+    ffn::expert_ggml::GgmlFFN,
     x::{self},
 };
 
+pub mod expert_ggml;
 #[allow(dead_code)]
 pub mod expert_ort;
 pub mod expert_torch;
@@ -18,6 +20,7 @@ pub mod meta;
 pub enum ExpertBackend {
     Torch(TorchFFN),
     OnnxF32(OnnxFFN<f32>),
+    Ggml(GgmlFFN),
 }
 
 impl ExpertBackend {
@@ -30,6 +33,10 @@ impl ExpertBackend {
                 let weight = ExpertWeight::<TchTensor>::from_safetensor(tensor, instance.device)?;
                 ExpertBackend::Torch(TorchFFN::construct(instance, weight)?)
             }
+            x::ExpertBackendType::Ggml => {
+                let weight = ExpertWeight::<GgmlTensor>::from_safetensor(tensor, instance.device)?;
+                ExpertBackend::Ggml(expert_ggml::GgmlFFN::construct(instance, weight)?)
+            }
             x::ExpertBackendType::Onnx => todo!(),
         };
         Ok(backend)
@@ -38,7 +45,7 @@ impl ExpertBackend {
 
 impl ExpertBackend {
     #[instrument(skip(self, view))]
-    pub fn forward(&self, view: &TensorView) -> EKResult<TchTensor> {
+    pub fn forward(&self, view: &TensorView) -> EKResult<Vec<u8>> {
         match self {
             ExpertBackend::Torch(exp) => {
                 let inp = TchTensor::from_tensor_view(view);
@@ -46,10 +53,17 @@ impl ExpertBackend {
                 let inp = inp.to_device(exp.device());
                 log::debug!("input shape {shape:?}");
                 assert!(shape.len() == 2);
-                Ok(exp.forward(&inp))
+                Ok(exp.forward(&inp).serialize())
             }
             ExpertBackend::OnnxF32(_exp) => {
                 todo!()
+            }
+            ExpertBackend::Ggml(exp) => {
+                let inp = GgmlTensor::from_tensor_view(view);
+                let shape = inp.shape();
+                log::debug!("input shape {shape:?}");
+                assert!(shape.len() == 2);
+                Ok(exp.forward(&inp).serialize())
             }
         }
     }

--- a/ek-computation/src/worker/core.rs
+++ b/ek-computation/src/worker/core.rs
@@ -1,9 +1,5 @@
 use super::manager::{ExpertDB, ExpertDBSync, get_expert_db, get_expert_db_sync};
-use crate::{
-    backend::{EkTensor, torch::TchTensor},
-    controller::registry::ExpertIdRef,
-    proto::ek,
-};
+use crate::{controller::registry::ExpertIdRef, proto::ek};
 use core::fmt;
 use ek_base::error::EKResult;
 use std::sync::{Arc, OnceLock};
@@ -113,18 +109,9 @@ impl EKInstanceGateSync {
             now.elapsed()
         );
 
-        // Serialize output
-        let output_tensor = res.inner();
-        let size = output_tensor.size();
-        let kind = output_tensor.kind();
-        let output_bytes = TchTensor::from(output_tensor).serialize();
+        let output_bytes = res;
 
-        tracing::debug!(
-            "output shape={:?} dtype={:?} bytes_len={}",
-            size,
-            kind,
-            output_bytes.len()
-        );
+        tracing::debug!("output bytes_len={}", output_bytes.len());
 
         let resp = ek::worker::v1::ForwardResp {
             output_tensor: output_bytes,
@@ -148,7 +135,7 @@ impl EKInstanceGateSync {
         let st = safetensors::SafeTensors::deserialize(input_tensor)?;
         let tv = st.tensor("data")?;
         let res = exp.forward(&tv)?;
-        Ok(res.serialize())
+        Ok(res)
     }
 
     /// Get list of currently loaded experts (sync version)

--- a/ek-computation/src/worker/x.rs
+++ b/ek-computation/src/worker/x.rs
@@ -32,6 +32,11 @@ pub async fn load_expert_task(
         let st = rg.load(expert_key).await?;
         let backend = ExpertBackend::build(instance, &st).await?;
 
+        if get_ek_settings().worker.drop_cache {
+            // If drop_cache is enabled, remove the tensor after building the backend
+            rg.remove(expert_key).await?;
+        }
+
         // Insert loaded expert into shared database (accessible by both async and sync gates)
         let mut edb_wg = expert_db.write().await;
         edb_wg.insert(&expert_str_key, backend).await?;

--- a/ek-computation/src/x.rs
+++ b/ek-computation/src/x.rs
@@ -20,6 +20,7 @@ static INSTANCE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 pub enum ExpertBackendType {
     Torch,
     Onnx,
+    Ggml,
 }
 
 impl From<&str> for ExpertBackendType {
@@ -27,6 +28,7 @@ impl From<&str> for ExpertBackendType {
         match value {
             "torch" => ExpertBackendType::Torch,
             "ort" => ExpertBackendType::Onnx,
+            "ggml" => ExpertBackendType::Ggml,
             _ => unimplemented!(),
         }
     }

--- a/ek-computation/src/x.rs
+++ b/ek-computation/src/x.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt::Display,
     path::PathBuf,
     sync::{
         Arc, OnceLock,
@@ -23,13 +24,25 @@ pub enum ExpertBackendType {
     Ggml,
 }
 
-impl From<&str> for ExpertBackendType {
-    fn from(value: &str) -> Self {
+impl TryFrom<&str> for ExpertBackendType {
+    type Error = &'static str;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
         match value {
-            "torch" => ExpertBackendType::Torch,
-            "ort" => ExpertBackendType::Onnx,
-            "ggml" => ExpertBackendType::Ggml,
-            _ => unimplemented!(),
+            "torch" => Ok(ExpertBackendType::Torch),
+            "ort" => Ok(ExpertBackendType::Onnx),
+            "ggml" => Ok(ExpertBackendType::Ggml),
+            _ => Err("Unknown backend type"),
+        }
+    }
+}
+
+impl Display for ExpertBackendType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExpertBackendType::Torch => write!(f, "torch"),
+            ExpertBackendType::Onnx => write!(f, "onnx"),
+            ExpertBackendType::Ggml => write!(f, "ggml"),
         }
     }
 }
@@ -52,7 +65,7 @@ impl Default for EKInstance {
         Self {
             hidden: settings.inference.hidden_dim,
             intermediate: settings.inference.intermediate_dim,
-            backend: ExpertBackendType::Torch,
+            backend: ExpertBackendType::try_from(settings.worker.backend.as_str()).unwrap(),
             device,
         }
     }

--- a/ek-db/src/safetensor/memcache.rs
+++ b/ek-db/src/safetensor/memcache.rs
@@ -44,6 +44,12 @@ impl MemCache {
         let m = unsafe { &mut (*self.map.get()) };
         m.insert(key.to_owned(), value);
     }
+
+    pub fn remove(&self, key: &str) {
+        let _wg = self.mu.write().unwrap();
+        let m = unsafe { &mut (*self.map.get()) };
+        m.remove(key);
+    }
 }
 
 unsafe impl Send for MemCache {}

--- a/ek-db/src/safetensor/mod.rs
+++ b/ek-db/src/safetensor/mod.rs
@@ -172,6 +172,12 @@ impl SafeTensorDB {
         let st = self.as_safetensor(&key)?;
         Ok(st)
     }
+
+    pub async fn remove(&self, desc: &ExpertKey) -> EKResult<()> {
+        let key = desc.as_object_key();
+        self.data.remove(&key);
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/ek-ggml/Cargo.toml
+++ b/ek-ggml/Cargo.toml
@@ -7,11 +7,6 @@ license = { workspace = true }
 readme = { workspace = true }
 repository = { workspace = true }
 
-[features]
-cublas = []
-clblast = []
-metal = []
-
 [dependencies]
 
 [build-dependencies]

--- a/ek-ggml/Cargo.toml
+++ b/ek-ggml/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "ek-ggml"
+version = { workspace = true }
+edition = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
+
+[features]
+cublas = []
+clblast = []
+metal = []
+
+[dependencies]
+
+[build-dependencies]
+bindgen = { workspace = true }
+cmake = { workspace = true }
+
+[dev-dependencies]
+rand = { workspace = true }

--- a/ek-ggml/build.rs
+++ b/ek-ggml/build.rs
@@ -1,0 +1,37 @@
+use std::{env, path::PathBuf};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=ggml");
+
+    let dst = cmake::Config::new("ggml")
+        .profile("Release")
+        // .define("GGML_STATIC", "ON")
+        .define("GGML_LLAMAFILE", "ON")
+        .define("GGML_CUDA", "ON")
+        .build();
+
+    println!("cargo:rustc-link-search=native={}/lib", dst.display());
+    println!("cargo:rustc-link-lib=dylib=ggml");
+    println!("cargo:rustc-link-lib=dylib=ggml-base");
+    println!("cargo:rustc-link-lib=dylib=ggml-cpu");
+    println!("cargo:rustc-link-lib=dylib=ggml-cuda");
+
+    let mut bindings = bindgen::Builder::default();
+
+    for header in dst.join("include").read_dir()? {
+        if let Ok(header) = header
+            && ["ggml.h", "ggml-cpu.h", "ggml-cuda.h"]
+                .contains(&header.file_name().to_str().unwrap())
+        {
+            bindings = bindings.header(header.path().to_string_lossy());
+        }
+    }
+
+    let bindings = bindings.generate()?;
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings.write_to_file(out_path.join("bindings.rs"))?;
+
+    Ok(())
+}

--- a/ek-ggml/build.rs
+++ b/ek-ggml/build.rs
@@ -6,7 +6,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let dst = cmake::Config::new("ggml")
         .profile("Release")
-        // .define("GGML_STATIC", "ON")
         .define("GGML_LLAMAFILE", "ON")
         .define("GGML_CUDA", "ON")
         .build();

--- a/ek-ggml/build.rs
+++ b/ek-ggml/build.rs
@@ -8,14 +8,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .define("BUILD_SHARED_LIBS", "OFF")
         .define("GGML_STATIC", "ON")
         .define("GGML_LLAMAFILE", "ON")
-        .define("GGML_CUDA", "ON")
         .build();
 
     println!("cargo:rustc-link-search=native={}/lib", dst.display());
     println!("cargo:rustc-link-lib=static=ggml");
     println!("cargo:rustc-link-lib=static=ggml-base");
     println!("cargo:rustc-link-lib=static=ggml-cpu");
-    println!("cargo:rustc-link-lib=static=ggml-cuda");
     println!("cargo:rustc-link-lib=dylib=gomp");
     println!("cargo:rustc-link-lib=dylib=stdc++");
 
@@ -23,8 +21,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for header in dst.join("include").read_dir()? {
         if let Ok(header) = header
-            && ["ggml.h", "ggml-cpu.h", "ggml-cuda.h"]
-                .contains(&header.file_name().to_str().unwrap())
+            && ["ggml.h", "ggml-cpu.h"].contains(&header.file_name().to_str().unwrap())
         {
             bindings = bindings.header(header.path().to_string_lossy());
         }

--- a/ek-ggml/build.rs
+++ b/ek-ggml/build.rs
@@ -5,16 +5,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=ggml");
 
     let dst = cmake::Config::new("ggml")
-        .profile("Release")
+        .define("BUILD_SHARED_LIBS", "OFF")
+        .define("GGML_STATIC", "ON")
         .define("GGML_LLAMAFILE", "ON")
         .define("GGML_CUDA", "ON")
         .build();
 
     println!("cargo:rustc-link-search=native={}/lib", dst.display());
-    println!("cargo:rustc-link-lib=dylib=ggml");
-    println!("cargo:rustc-link-lib=dylib=ggml-base");
-    println!("cargo:rustc-link-lib=dylib=ggml-cpu");
-    println!("cargo:rustc-link-lib=dylib=ggml-cuda");
+    println!("cargo:rustc-link-lib=static=ggml");
+    println!("cargo:rustc-link-lib=static=ggml-base");
+    println!("cargo:rustc-link-lib=static=ggml-cpu");
+    println!("cargo:rustc-link-lib=static=ggml-cuda");
+    println!("cargo:rustc-link-lib=dylib=gomp");
+    println!("cargo:rustc-link-lib=dylib=stdc++");
 
     let mut bindings = bindgen::Builder::default();
 

--- a/ek-ggml/build.rs
+++ b/ek-ggml/build.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for header in dst.join("include").read_dir()? {
         if let Ok(header) = header
-            && ["ggml.h", "ggml-cpu.h"].contains(&header.file_name().to_str().unwrap())
+            && ["ggml-cpu.h"].contains(&header.file_name().to_str().unwrap())
         {
             bindings = bindings.header(header.path().to_string_lossy());
         }

--- a/ek-ggml/src/core.rs
+++ b/ek-ggml/src/core.rs
@@ -1,0 +1,366 @@
+use std::{cell::OnceCell, ptr::NonNull};
+
+use crate::bindings::{ggml_dup_tensor, ggml_n_dims, ggml_type_size};
+
+#[allow(warnings)]
+pub(crate) mod bindings {
+    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+}
+
+#[derive(Debug)]
+pub struct Context {
+    ptr: NonNull<bindings::ggml_context>,
+}
+
+thread_local! {
+    static CONTEXT: OnceCell<Context> = OnceCell::new();
+}
+
+impl Context {
+    pub fn init(size: usize) {
+        CONTEXT.with(|ctx| {
+            ctx.get_or_init(|| Context::new(size));
+        });
+    }
+
+    fn new(size: usize) -> Self {
+        let params = bindings::ggml_init_params {
+            mem_buffer: std::ptr::null_mut(),
+            mem_size: size,
+            no_alloc: false,
+        };
+
+        let ctx = unsafe { bindings::ggml_init(params) };
+
+        Self {
+            ptr: NonNull::new(ctx).unwrap(),
+        }
+    }
+}
+
+unsafe impl Send for Context {}
+
+impl Drop for Context {
+    fn drop(&mut self) {
+        unsafe { bindings::ggml_free(self.ptr.as_ptr()) };
+    }
+}
+
+pub struct Graph {
+    ctx: NonNull<bindings::ggml_context>,
+    ptr: NonNull<bindings::ggml_cgraph>,
+}
+
+impl Graph {
+    pub fn new() -> Self {
+        CONTEXT.with(|ctx| {
+            let ctx = ctx.get().expect("Context not initialized");
+            let graph = unsafe { bindings::ggml_new_graph(ctx.ptr.as_ptr()) };
+
+            Self {
+                ctx: NonNull::new(ctx.ptr.as_ptr()).unwrap(),
+                ptr: NonNull::new(graph).unwrap(),
+            }
+        })
+    }
+
+    pub fn build_forward(&mut self, tensor: &Tensor) {
+        unsafe { bindings::ggml_build_forward_expand(self.ptr.as_mut(), tensor.ptr) };
+    }
+
+    pub fn compute(&mut self, n_threads: usize) {
+        unsafe {
+            bindings::ggml_graph_compute_with_ctx(
+                self.ctx.as_ptr(),
+                self.ptr.as_mut(),
+                n_threads as _,
+            )
+        };
+    }
+}
+
+unsafe impl Send for Graph {}
+
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Kind {
+    F32 = bindings::ggml_type_GGML_TYPE_F32,
+}
+
+impl Kind {
+    pub fn size(&self) -> usize {
+        let ggml_type: bindings::ggml_type = *self as _;
+        unsafe { bindings::ggml_type_size(ggml_type) }
+    }
+}
+
+impl From<bindings::ggml_type> for Kind {
+    fn from(ggml_type: bindings::ggml_type) -> Self {
+        match ggml_type {
+            bindings::ggml_type_GGML_TYPE_F32 => Kind::F32,
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Tensor {
+    ctx: NonNull<bindings::ggml_context>,
+    ptr: *mut bindings::ggml_tensor,
+}
+
+impl Tensor {
+    pub fn empty(shape: &[i64], kind: Kind) -> Option<Self> {
+        CONTEXT.with(|ctx| {
+            let ctx = ctx.get().expect("Context not initialized");
+            let ne: Vec<i64> = shape.iter().rev().cloned().collect();
+            let tensor = unsafe {
+                bindings::ggml_new_tensor(
+                    ctx.ptr.as_ptr(),
+                    kind as _,
+                    ne.len() as _,
+                    ne.as_ptr() as _,
+                )
+            };
+            Some(Self {
+                ctx: NonNull::new(ctx.ptr.as_ptr())?,
+                ptr: tensor,
+            })
+        })
+    }
+
+    pub unsafe fn from_raw(data: &[u8], shape: &[i64], kind: Kind) -> Option<Self> {
+        CONTEXT.with(|ctx| {
+            let ctx = ctx.get().expect("Context not initialized");
+            let ne: Vec<i64> = shape.iter().rev().cloned().collect();
+            let tensor = unsafe {
+                &mut *bindings::ggml_new_tensor(
+                    ctx.ptr.as_ptr(),
+                    kind as _,
+                    ne.len() as _,
+                    ne.as_ptr() as *const _,
+                )
+            };
+
+            unsafe {
+                tensor
+                    .data
+                    .copy_from_nonoverlapping(data.as_ptr() as _, data.len())
+            };
+
+            Some(Self {
+                ctx: NonNull::new(ctx.ptr.as_ptr()).unwrap(),
+                ptr: tensor,
+            })
+        })
+    }
+
+    pub fn set_data(&mut self, data: &[u8]) -> Result<(), (usize, usize)> {
+        let inner = unsafe { &mut *self.ptr };
+        let inner_size =
+            unsafe { ggml_type_size(inner.type_) * inner.ne.iter().product::<i64>() as usize };
+        if data.len() != inner_size {
+            return Err((data.len(), inner_size));
+        }
+        unsafe {
+            inner
+                .data
+                .copy_from_nonoverlapping(data.as_ptr() as _, data.len())
+        };
+        Ok(())
+    }
+
+    pub fn shape(&self) -> Vec<i64> {
+        let n_dim = unsafe { ggml_n_dims(self.ptr) };
+        let inner = unsafe { &*self.ptr };
+        inner.ne.iter().take(n_dim as _).rev().cloned().collect()
+    }
+
+    pub fn raw_data(&self) -> &[u8] {
+        let inner = unsafe { &*self.ptr };
+        let numel = inner.ne.iter().product::<i64>() as usize;
+        unsafe {
+            std::slice::from_raw_parts(inner.data as *const u8, ggml_type_size(inner.type_) * numel)
+        }
+    }
+
+    pub fn matmul(&self, other: &Tensor) -> Tensor {
+        let tensor =
+            unsafe { bindings::ggml_mul_mat(self.ctx.as_ptr(), &mut *self.ptr, &mut *other.ptr) };
+        Self {
+            ctx: self.ctx,
+            ptr: tensor,
+        }
+    }
+
+    pub fn mul(&self, other: &Tensor) -> Tensor {
+        let tensor =
+            unsafe { bindings::ggml_mul(self.ctx.as_ptr(), &mut *self.ptr, &mut *other.ptr) };
+        Self {
+            ctx: self.ctx,
+            ptr: tensor,
+        }
+    }
+
+    pub fn sub(&self, other: &Tensor) -> Tensor {
+        let tensor =
+            unsafe { bindings::ggml_sub(self.ctx.as_ptr(), &mut *self.ptr, &mut *other.ptr) };
+        Self {
+            ctx: self.ctx,
+            ptr: tensor,
+        }
+    }
+
+    pub fn sum(&self) -> Tensor {
+        let tensor = unsafe { bindings::ggml_sum(self.ctx.as_ptr(), &mut *self.ptr) };
+        Self {
+            ctx: self.ctx,
+            ptr: tensor,
+        }
+    }
+    pub fn silu(&self) -> Tensor {
+        let tensor = unsafe { bindings::ggml_silu(self.ctx.as_ptr(), &mut *self.ptr) };
+        Self {
+            ctx: self.ctx,
+            ptr: tensor,
+        }
+    }
+
+    pub fn transpose(&self) -> Tensor {
+        self.transpose_view().cont()
+    }
+
+    pub fn transpose_view(&self) -> Tensor {
+        let tensor = unsafe { bindings::ggml_transpose(self.ctx.as_ptr(), &mut *self.ptr) };
+        Self {
+            ctx: self.ctx,
+            ptr: tensor,
+        }
+    }
+
+    pub fn cont(&self) -> Tensor {
+        let tensor = unsafe { bindings::ggml_cont(self.ctx.as_ptr(), &mut *self.ptr) };
+        Self {
+            ctx: self.ctx,
+            ptr: tensor,
+        }
+    }
+
+    pub fn cast(&self, kind: Kind) -> Tensor {
+        let tensor = unsafe { bindings::ggml_cast(self.ctx.as_ptr(), &mut *self.ptr, kind as _) };
+        Self {
+            ctx: self.ctx,
+            ptr: tensor,
+        }
+    }
+
+    pub fn kind(&self) -> Kind {
+        let inner = unsafe { &*self.ptr };
+        Kind::from(inner.type_)
+    }
+}
+
+impl Clone for Tensor {
+    fn clone(&self) -> Self {
+        let ptr = unsafe { ggml_dup_tensor(self.ctx.as_ptr(), &mut *self.ptr) };
+        Self { ctx: self.ctx, ptr }
+    }
+}
+
+unsafe impl Send for Tensor {}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn matmul<const N: usize>(a: &[f32; N], b: &[f32; N]) -> Vec<f32> {
+        let mut c = Vec::with_capacity(N * N); // C^T = A * B^T
+        for j in 0..N {
+            for i in 0..N {
+                c.push(a[i] * b[j]);
+            }
+        }
+        c
+    }
+
+    fn tensor(a: &[f32]) -> Tensor {
+        let len = a.len();
+        let a = unsafe {
+            std::slice::from_raw_parts_mut(
+                a.as_ptr() as *mut _,
+                a.len() * std::mem::size_of::<f32>(),
+            )
+        };
+        unsafe { Tensor::from_raw(a, &[len as _, 1], Kind::F32).unwrap() }
+    }
+
+    #[test]
+    fn test_tensor_mul() -> Result<(), Box<dyn std::error::Error>> {
+        Context::init(1024 * 1024);
+
+        let a: [f32; 3] = [1.0, 2.0, 3.0];
+        let b: [f32; 3] = [4.0, 5.0, 6.0];
+
+        let expected_c = matmul(&a, &b);
+
+        let mut tensor_a = tensor(&a);
+        let mut tensor_b = tensor(&b);
+
+        assert_eq!(tensor_a.shape(), &[3, 1]);
+        assert_eq!(tensor_b.shape(), &[3, 1]);
+        let mut tensor_c = tensor_a.matmul(&mut tensor_b);
+
+        let mut graph = Graph::new();
+        graph.build_forward(&mut tensor_c);
+        graph.compute(1);
+        let c_data = tensor_c.raw_data();
+        let result = unsafe {
+            std::slice::from_raw_parts_mut(
+                c_data.as_ptr() as *mut f32,
+                c_data.len() / std::mem::size_of::<f32>(),
+            )
+        };
+
+        assert_eq!(result, &expected_c);
+
+        for _ in 0..32 {
+            let mut a: [f32; 3] = [0.0; 3];
+            let mut b: [f32; 3] = [0.0; 3];
+            for i in 0..3 {
+                a[i] = rand::random();
+                b[i] = rand::random();
+            }
+
+            let expected_c = matmul(&a, &b);
+
+            let a = unsafe {
+                std::slice::from_raw_parts_mut(
+                    a.as_ptr() as _,
+                    a.len() * std::mem::size_of::<f32>(),
+                )
+            };
+            let b = unsafe {
+                std::slice::from_raw_parts_mut(
+                    b.as_ptr() as _,
+                    b.len() * std::mem::size_of::<f32>(),
+                )
+            };
+
+            tensor_a.set_data(a).unwrap();
+            tensor_b.set_data(b).unwrap();
+
+            graph.compute(1);
+            let c_data = tensor_c.raw_data();
+            let result = unsafe {
+                std::slice::from_raw_parts_mut(
+                    c_data.as_ptr() as *mut f32,
+                    c_data.len() / std::mem::size_of::<f32>(),
+                )
+            };
+
+            assert_eq!(result, &expected_c);
+        }
+
+        Ok(())
+    }
+}

--- a/ek-ggml/src/core.rs
+++ b/ek-ggml/src/core.rs
@@ -183,7 +183,7 @@ pub struct TensorAllocator {
 }
 
 impl TensorAllocator {
-    pub fn borrow_shared<'a>(&self, tensor: &'a SharedTensor) -> &'a Tensor {
+    pub fn borrow<'a>(&self, tensor: &'a SharedTensor) -> &'a Tensor {
         &tensor.0
     }
 
@@ -310,6 +310,12 @@ impl Tensor {
     pub fn kind(&self) -> Kind {
         let inner = unsafe { &*self.ptr };
         Kind::from(inner.type_)
+    }
+
+    pub fn shape(&self) -> Vec<i64> {
+        let n_dim = unsafe { ggml_n_dims(self.ptr) };
+        let inner = unsafe { &*self.ptr };
+        inner.ne.iter().take(n_dim as _).rev().cloned().collect()
     }
 }
 

--- a/ek-ggml/src/core.rs
+++ b/ek-ggml/src/core.rs
@@ -27,16 +27,12 @@ impl Context {
         }
     }
 
-    pub fn create_graph(&mut self) -> Graph {
-        let graph = unsafe { bindings::ggml_new_graph(self.ptr.as_ptr()) };
-
-        Graph {
-            ctx: NonNull::new(self.ptr.as_ptr()).unwrap(),
-            ptr: NonNull::new(graph).unwrap(),
-        }
-    }
-
-    pub fn create_tensor(&mut self, shape: &[i64], kind: Kind) -> Tensor {
+    pub fn create_tensor(
+        &self,
+        shape: &[i64],
+        kind: Kind,
+        data: Vec<u8>,
+    ) -> Result<SharedTensor, Error> {
         let ne = shape.iter().rev().cloned().collect::<Vec<_>>();
         let tensor = unsafe {
             bindings::ggml_new_tensor(
@@ -46,9 +42,36 @@ impl Context {
                 ne.as_ptr() as _,
             )
         };
+
+        let tensor = unsafe { &mut *tensor };
         Tensor {
-            ctx: NonNull::new(self.ptr.as_ptr()).unwrap(),
+            ctx: self.ptr,
             ptr: tensor,
+        }
+        .set_data(&data)?;
+
+        Ok(SharedTensor(Tensor {
+            ctx: self.ptr,
+            ptr: tensor,
+        }))
+    }
+
+    pub fn create_graph<const N: usize>(
+        &self,
+        compute: impl FnOnce(&TensorAllocator) -> ([Tensor; N], Tensor),
+    ) -> Graph<N> {
+        let graph = unsafe { bindings::ggml_new_graph(self.ptr.as_ptr()) };
+
+        let allocator = TensorAllocator { ctx: self.ptr };
+        let (inputs, output) = compute(&allocator);
+
+        unsafe { bindings::ggml_build_forward_expand(graph, output.ptr) };
+
+        Graph {
+            ctx: NonNull::new(self.ptr.as_ptr()).unwrap(),
+            ptr: NonNull::new(graph).unwrap(),
+            inputs: inputs.map(|input| input.ptr),
+            output: output.ptr,
         }
     }
 }
@@ -61,21 +84,53 @@ impl Drop for Context {
     }
 }
 
-pub struct Graph {
+pub struct Graph<const N: usize> {
     ctx: NonNull<bindings::ggml_context>,
     ptr: NonNull<bindings::ggml_cgraph>,
+    inputs: [*mut bindings::ggml_tensor; N],
+    output: *mut bindings::ggml_tensor,
 }
 
-impl Graph {
+impl<const N: usize> Graph<N> {
     pub fn overhead() -> usize {
         unsafe { bindings::ggml_graph_overhead() }
     }
 
-    pub fn build_forward(&mut self, tensor: &Tensor) {
-        unsafe { bindings::ggml_build_forward_expand(self.ptr.as_mut(), tensor.ptr) };
+    pub fn inputs_kind(&self) -> [Kind; N] {
+        self.inputs.map(|tensor| {
+            let inner = unsafe { &*tensor };
+            inner.type_.into()
+        })
     }
 
-    pub fn compute(&mut self, n_threads: usize) {
+    pub fn output_kind(&self) -> Kind {
+        let inner = unsafe { &*self.output };
+        inner.type_.into()
+    }
+
+    pub fn inputs_shape(&self) -> [Vec<i64>; N] {
+        self.inputs.map(|tensor| {
+            let n_dim = unsafe { ggml_n_dims(tensor) };
+            let inner = unsafe { &*tensor };
+            inner.ne.iter().take(n_dim as _).rev().cloned().collect()
+        })
+    }
+
+    pub fn output_shape(&self) -> Vec<i64> {
+        let n_dim = unsafe { ggml_n_dims(self.output) };
+        let inner = unsafe { &*self.output };
+        inner.ne.iter().take(n_dim as _).rev().cloned().collect()
+    }
+
+    pub fn compute(&mut self, inputs: [&[u8]; N], n_threads: usize) -> Result<Vec<u8>, Error> {
+        for (&tensor, &data) in self.inputs.iter().zip(inputs.iter()) {
+            let tensor = Tensor {
+                ctx: self.ctx,
+                ptr: tensor,
+            };
+            tensor.set_data(data)?;
+        }
+
         unsafe {
             bindings::ggml_graph_compute_with_ctx(
                 self.ctx.as_ptr(),
@@ -83,13 +138,22 @@ impl Graph {
                 n_threads as _,
             )
         };
+
+        let output = unsafe { &mut *self.output };
+        let output = Tensor {
+            ctx: self.ctx,
+            ptr: output,
+        };
+
+        Ok(output.get_data().to_vec())
     }
 }
 
-unsafe impl Send for Graph {}
+unsafe impl<const N: usize> Send for Graph<N> {}
 
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum Kind {
     F32 = bindings::ggml_type_GGML_TYPE_F32,
     BF16 = bindings::ggml_type_GGML_TYPE_BF16,
@@ -114,6 +178,35 @@ impl From<bindings::ggml_type> for Kind {
     }
 }
 
+pub struct TensorAllocator {
+    ctx: NonNull<bindings::ggml_context>,
+}
+
+impl TensorAllocator {
+    pub fn borrow_shared<'a>(&self, tensor: &'a SharedTensor) -> &'a Tensor {
+        &tensor.0
+    }
+
+    pub fn alloc(&self, shape: &[i64], kind: Kind) -> Tensor {
+        let ne = shape.iter().rev().cloned().collect::<Vec<_>>();
+        let tensor = unsafe {
+            bindings::ggml_new_tensor(
+                self.ctx.as_ptr(),
+                kind as _,
+                ne.len() as _,
+                ne.as_ptr() as _,
+            )
+        };
+
+        Tensor {
+            ctx: self.ctx,
+            ptr: tensor,
+        }
+    }
+}
+
+pub struct SharedTensor(Tensor);
+
 #[derive(Debug)]
 pub struct Tensor {
     ctx: NonNull<bindings::ggml_context>,
@@ -124,35 +217,6 @@ impl Tensor {
     #[inline]
     pub fn overhead() -> usize {
         unsafe { ggml_tensor_overhead() }
-    }
-
-    pub fn set_data(&mut self, data: &[u8]) -> Result<(), (usize, usize)> {
-        let inner = unsafe { &mut *self.ptr };
-        let inner_size =
-            unsafe { ggml_type_size(inner.type_) * inner.ne.iter().product::<i64>() as usize };
-        if data.len() != inner_size {
-            return Err((data.len(), inner_size));
-        }
-        unsafe {
-            inner
-                .data
-                .copy_from_nonoverlapping(data.as_ptr() as _, data.len())
-        };
-        Ok(())
-    }
-
-    pub fn get_data(&self) -> &[u8] {
-        let inner = unsafe { &*self.ptr };
-        let numel = inner.ne.iter().product::<i64>() as usize;
-        unsafe {
-            std::slice::from_raw_parts(inner.data as *const u8, ggml_type_size(inner.type_) * numel)
-        }
-    }
-
-    pub fn shape(&self) -> Vec<i64> {
-        let n_dim = unsafe { ggml_n_dims(self.ptr) };
-        let inner = unsafe { &*self.ptr };
-        inner.ne.iter().take(n_dim as _).rev().cloned().collect()
     }
 
     pub fn matmul(&self, other: &Self) -> Self {
@@ -249,6 +313,30 @@ impl Tensor {
     }
 }
 
+impl Tensor {
+    fn set_data(&self, data: &[u8]) -> Result<(), Error> {
+        let inner = unsafe { &mut *self.ptr };
+        let numel = inner.ne.iter().product::<i64>() as usize;
+        let inner_size = unsafe { ggml_type_size(inner.type_) * numel };
+        if data.len() != inner_size {
+            return Err(Error::DimensionMismatch(data.len(), inner_size));
+        }
+        unsafe {
+            inner
+                .data
+                .copy_from_nonoverlapping(data.as_ptr() as _, data.len())
+        };
+        Ok(())
+    }
+
+    fn get_data(&self) -> &[u8] {
+        let inner = unsafe { &*self.ptr };
+        let numel = inner.ne.iter().product::<i64>() as usize;
+        let inner_size = unsafe { ggml_type_size(inner.type_) * numel };
+        unsafe { std::slice::from_raw_parts(inner.data as *const u8, inner_size) }
+    }
+}
+
 impl Clone for Tensor {
     fn clone(&self) -> Self {
         let ptr = unsafe { ggml_dup_tensor(self.ctx.as_ptr(), self.ptr) };
@@ -257,6 +345,24 @@ impl Clone for Tensor {
 }
 
 unsafe impl Send for Tensor {}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum Error {
+    DimensionMismatch(usize, usize),
+}
+
+impl std::error::Error for Error {}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::DimensionMismatch(got, expected) => {
+                write!(f, "Dimension mismatch: got {}, expected {}", got, expected)
+            }
+        }
+    }
+}
 
 #[cfg(test)]
 mod test {
@@ -272,51 +378,37 @@ mod test {
         c
     }
 
-    fn set_tensor(tensor: &mut Tensor, data: &[f32]) {
-        let tensor_data = unsafe {
-            std::slice::from_raw_parts_mut(data.as_ptr() as *mut _, std::mem::size_of_val(data))
-        };
-        tensor.set_data(tensor_data).unwrap();
-    }
-
-    fn chk_tensor(tensor: &Tensor, data: &[f32]) {
-        let tensor_data = tensor.get_data();
-        let result = unsafe {
-            std::slice::from_raw_parts_mut(
-                tensor_data.as_ptr() as *mut f32,
-                tensor_data.len() / std::mem::size_of::<f32>(),
-            )
-        };
-        assert_eq!(result, data);
+    fn slice_to_u8<T>(s: &[T]) -> &[u8] {
+        let len = std::mem::size_of_val(s);
+        let ptr = s.as_ptr() as *const u8;
+        unsafe { std::slice::from_raw_parts(ptr, len) }
     }
 
     #[test]
     fn test_tensor_mul() -> Result<(), Box<dyn std::error::Error>> {
-        let mut ctx = Context::new(1024 * 1024);
+        let ctx = Context::new(1024 * 1024);
 
         let a: [f32; 3] = [1.0, 2.0, 3.0];
         let b: [f32; 3] = [4.0, 5.0, 6.0];
 
         let expected_c = matmul(&a, &b);
 
-        let mut tensor_a = ctx.create_tensor(&[3, 1], Kind::F32);
-        let mut tensor_b = ctx.create_tensor(&[3, 1], Kind::F32);
+        let mut graph = ctx.create_graph(|allocator| {
+            let tensor_a = allocator.alloc(&[3, 1], Kind::F32);
+            let tensor_b = allocator.alloc(&[3, 1], Kind::F32);
+            let tensor_c = tensor_a.matmul(&tensor_b);
+            ([tensor_a, tensor_b], tensor_c)
+        });
 
-        assert_eq!(tensor_a.shape(), &[3, 1]);
-        assert_eq!(tensor_b.shape(), &[3, 1]);
+        let inputs_shape = graph.inputs_shape();
+        let output_shape = graph.output_shape();
 
-        let tensor_c = tensor_a.matmul(&tensor_b);
+        assert_eq!(inputs_shape, [&[3, 1], &[3, 1]]);
+        assert_eq!(output_shape, &[3, 3]);
 
-        let mut graph = ctx.create_graph();
+        let output = graph.compute([slice_to_u8(&a), slice_to_u8(&b)], 1)?;
 
-        graph.build_forward(&tensor_c);
-
-        set_tensor(&mut tensor_a, &a);
-        set_tensor(&mut tensor_b, &b);
-
-        graph.compute(1);
-
-        chk_tensor(&tensor_c, &expected_c);
+        assert_eq!(output, slice_to_u8(&expected_c));
 
         for _ in 0..32 {
             let mut a: [f32; 3] = [0.0; 3];
@@ -328,12 +420,9 @@ mod test {
 
             let expected_c = matmul(&a, &b);
 
-            set_tensor(&mut tensor_a, &a);
-            set_tensor(&mut tensor_b, &b);
+            let output = graph.compute([slice_to_u8(&a), slice_to_u8(&b)], 1)?;
 
-            graph.compute(1);
-
-            chk_tensor(&tensor_c, &expected_c);
+            assert_eq!(output, slice_to_u8(&expected_c));
         }
 
         Ok(())

--- a/ek-ggml/src/core.rs
+++ b/ek-ggml/src/core.rs
@@ -265,7 +265,7 @@ impl TensorNode {
             Ok(Self::new_with_data_set(
                 inner.ctx,
                 tensor,
-                &[other.clone()],
+                std::slice::from_ref(&other.clone()),
                 inner.data,
             ))
         } else {

--- a/ek-ggml/src/core.rs
+++ b/ek-ggml/src/core.rs
@@ -1,6 +1,6 @@
-use std::ptr::NonNull;
+use std::{pin::Pin, ptr::NonNull, rc::Rc};
 
-use crate::bindings::{ggml_dup_tensor, ggml_n_dims, ggml_tensor_overhead, ggml_type_size};
+use crate::bindings::{ggml_graph_print, ggml_n_dims, ggml_tensor_overhead};
 
 #[allow(warnings)]
 pub(crate) mod bindings {
@@ -17,7 +17,7 @@ impl Context {
         let params = bindings::ggml_init_params {
             mem_buffer: std::ptr::null_mut(),
             mem_size: size,
-            no_alloc: false,
+            no_alloc: true,
         };
 
         let ctx = unsafe { bindings::ggml_init(params) };
@@ -31,7 +31,7 @@ impl Context {
         &self,
         shape: &[i64],
         kind: Kind,
-        data: Vec<u8>,
+        data: Box<[u8]>,
     ) -> Result<SharedTensor, Error> {
         let ne = shape.iter().rev().cloned().collect::<Vec<_>>();
         let tensor = unsafe {
@@ -43,36 +43,28 @@ impl Context {
             )
         };
 
-        let tensor = unsafe { &mut *tensor };
-        Tensor {
-            ctx: self.ptr,
-            ptr: tensor,
-        }
-        .set_data(&data)?;
+        let tensor = TensorNode::new_with_data_set(self.ptr, tensor, &[], Some(Pin::new(data)));
 
-        Ok(SharedTensor(Tensor {
-            ctx: self.ptr,
-            ptr: tensor,
-        }))
+        Ok(SharedTensor(tensor))
     }
 
     pub fn create_graph<const N: usize>(
         &self,
-        compute: impl FnOnce(&TensorAllocator) -> ([Tensor; N], Tensor),
-    ) -> Graph<N> {
+        compute: impl FnOnce(&TensorAllocator) -> Result<([TensorNode; N], TensorNode), Error>,
+    ) -> Result<Graph<N>, Error> {
         let graph = unsafe { bindings::ggml_new_graph(self.ptr.as_ptr()) };
 
         let allocator = TensorAllocator { ctx: self.ptr };
-        let (inputs, output) = compute(&allocator);
+        let (inputs, output) = compute(&allocator)?;
 
         unsafe { bindings::ggml_build_forward_expand(graph, output.ptr) };
 
-        Graph {
+        Ok(Graph {
             ctx: NonNull::new(self.ptr.as_ptr()).unwrap(),
             ptr: NonNull::new(graph).unwrap(),
-            inputs: inputs.map(|input| input.ptr),
-            output: output.ptr,
-        }
+            inputs,
+            output,
+        })
     }
 }
 
@@ -87,8 +79,8 @@ impl Drop for Context {
 pub struct Graph<const N: usize> {
     ctx: NonNull<bindings::ggml_context>,
     ptr: NonNull<bindings::ggml_cgraph>,
-    inputs: [*mut bindings::ggml_tensor; N],
-    output: *mut bindings::ggml_tensor,
+    inputs: [TensorNode; N],
+    output: TensorNode,
 }
 
 impl<const N: usize> Graph<N> {
@@ -96,56 +88,57 @@ impl<const N: usize> Graph<N> {
         unsafe { bindings::ggml_graph_overhead() }
     }
 
+    pub fn default_size() -> usize {
+        bindings::GGML_DEFAULT_GRAPH_SIZE as _
+    }
+
     pub fn inputs_kind(&self) -> [Kind; N] {
-        self.inputs.map(|tensor| {
-            let inner = unsafe { &*tensor };
-            inner.type_.into()
-        })
+        self.inputs.each_ref().map(|tensor| tensor.kind())
     }
 
     pub fn output_kind(&self) -> Kind {
-        let inner = unsafe { &*self.output };
-        inner.type_.into()
+        self.output.kind()
     }
 
     pub fn inputs_shape(&self) -> [Vec<i64>; N] {
-        self.inputs.map(|tensor| {
-            let n_dim = unsafe { ggml_n_dims(tensor) };
-            let inner = unsafe { &*tensor };
-            inner.ne.iter().take(n_dim as _).rev().cloned().collect()
-        })
+        self.inputs.each_ref().map(|tensor| tensor.shape())
     }
 
     pub fn output_shape(&self) -> Vec<i64> {
-        let n_dim = unsafe { ggml_n_dims(self.output) };
-        let inner = unsafe { &*self.output };
-        inner.ne.iter().take(n_dim as _).rev().cloned().collect()
+        self.output.shape()
     }
 
     pub fn compute(&mut self, inputs: [&[u8]; N], n_threads: usize) -> Result<Vec<u8>, Error> {
-        for (&tensor, &data) in self.inputs.iter().zip(inputs.iter()) {
-            let tensor = Tensor {
-                ctx: self.ctx,
-                ptr: tensor,
-            };
-            tensor.set_data(data)?;
+        for (tensor, &data) in self.inputs.iter_mut().zip(inputs.iter()) {
+            if tensor.data.is_some() {
+                return Err(Error::InputTensorDataFound);
+            }
+            unsafe { (*tensor.ptr).data = data.as_ptr() as _ };
         }
 
+        let mut result = vec![0u8; self.output.size()];
+
+        if let Some(place) = &self.output.data {
+            unsafe {
+                bindings::ggml_graph_compute_with_ctx(
+                    self.ctx.as_ptr(),
+                    self.ptr.as_mut(),
+                    n_threads as _,
+                )
+            };
+
+            result.copy_from_slice(place);
+        } else {
+            return Err(Error::OutputTensorDataNotFound);
+        }
+
+        Ok(result)
+    }
+
+    pub fn print(&self) {
         unsafe {
-            bindings::ggml_graph_compute_with_ctx(
-                self.ctx.as_ptr(),
-                self.ptr.as_mut(),
-                n_threads as _,
-            )
-        };
-
-        let output = unsafe { &mut *self.output };
-        let output = Tensor {
-            ctx: self.ctx,
-            ptr: output,
-        };
-
-        Ok(output.get_data().to_vec())
+            ggml_graph_print(self.ptr.as_ptr());
+        }
     }
 }
 
@@ -183,11 +176,11 @@ pub struct TensorAllocator {
 }
 
 impl TensorAllocator {
-    pub fn borrow<'a>(&self, tensor: &'a SharedTensor) -> &'a Tensor {
-        &tensor.0
+    pub fn borrow(&self, tensor: &SharedTensor) -> TensorNode {
+        tensor.0.clone()
     }
 
-    pub fn alloc(&self, shape: &[i64], kind: Kind) -> Tensor {
+    pub fn alloc(&self, shape: &[i64], kind: Kind) -> TensorNode {
         let ne = shape.iter().rev().cloned().collect::<Vec<_>>();
         let tensor = unsafe {
             bindings::ggml_new_tensor(
@@ -198,113 +191,28 @@ impl TensorAllocator {
             )
         };
 
-        Tensor {
-            ctx: self.ctx,
-            ptr: tensor,
+        TensorNode {
+            inner: Rc::new(Tensor {
+                ctx: self.ctx,
+                ptr: tensor,
+                data: None,
+            }),
+            _deps: Vec::new(),
         }
     }
 }
-
-pub struct SharedTensor(Tensor);
 
 #[derive(Debug)]
 pub struct Tensor {
     ctx: NonNull<bindings::ggml_context>,
     ptr: *mut bindings::ggml_tensor,
+    data: Option<Pin<Box<[u8]>>>,
 }
 
 impl Tensor {
     #[inline]
     pub fn overhead() -> usize {
         unsafe { ggml_tensor_overhead() }
-    }
-
-    pub fn matmul(&self, other: &Self) -> Self {
-        let tensor =
-            unsafe { bindings::ggml_mul_mat(self.ctx.as_ptr(), &mut *self.ptr, &mut *other.ptr) };
-        Self {
-            ctx: self.ctx,
-            ptr: tensor,
-        }
-    }
-
-    pub fn mul(&self, other: &Self) -> Self {
-        let tensor =
-            unsafe { bindings::ggml_mul(self.ctx.as_ptr(), &mut *self.ptr, &mut *other.ptr) };
-        Self {
-            ctx: self.ctx,
-            ptr: tensor,
-        }
-    }
-
-    pub fn mul_inplace(self, other: &Self) -> Self {
-        let tensor = unsafe {
-            bindings::ggml_mul_inplace(self.ctx.as_ptr(), &mut *self.ptr, &mut *other.ptr)
-        };
-        Self {
-            ctx: self.ctx,
-            ptr: tensor,
-        }
-    }
-
-    pub fn sub(&self, other: &Self) -> Self {
-        let tensor =
-            unsafe { bindings::ggml_sub(self.ctx.as_ptr(), &mut *self.ptr, &mut *other.ptr) };
-        Self {
-            ctx: self.ctx,
-            ptr: tensor,
-        }
-    }
-
-    pub fn sum(&self) -> Self {
-        let tensor = unsafe { bindings::ggml_sum(self.ctx.as_ptr(), &mut *self.ptr) };
-        Self {
-            ctx: self.ctx,
-            ptr: tensor,
-        }
-    }
-    pub fn silu(&self) -> Self {
-        let tensor = unsafe { bindings::ggml_silu(self.ctx.as_ptr(), &mut *self.ptr) };
-        Self {
-            ctx: self.ctx,
-            ptr: tensor,
-        }
-    }
-
-    pub fn silu_inplace(self) -> Self {
-        let tensor = unsafe { bindings::ggml_silu_inplace(self.ctx.as_ptr(), &mut *self.ptr) };
-        Self {
-            ctx: self.ctx,
-            ptr: tensor,
-        }
-    }
-
-    pub fn transpose(&self) -> Self {
-        self.transpose_view().cont()
-    }
-
-    pub fn transpose_view(&self) -> Self {
-        let tensor = unsafe { bindings::ggml_transpose(self.ctx.as_ptr(), &mut *self.ptr) };
-        Self {
-            ctx: self.ctx,
-            ptr: tensor,
-        }
-    }
-
-    pub fn cont(&self) -> Self {
-        let tensor = unsafe { bindings::ggml_cont(self.ctx.as_ptr(), &mut *self.ptr) };
-        Self {
-            ctx: self.ctx,
-            ptr: tensor,
-        }
-    }
-
-    pub fn cast(&self, kind: Kind) -> Self {
-        let tensor = unsafe { bindings::ggml_cast(self.ctx.as_ptr(), &mut *self.ptr, kind as _) };
-        Self {
-            ctx: self.ctx,
-            ptr: tensor,
-        }
     }
 
     pub fn kind(&self) -> Kind {
@@ -317,45 +225,146 @@ impl Tensor {
         let inner = unsafe { &*self.ptr };
         inner.ne.iter().take(n_dim as _).rev().cloned().collect()
     }
+
+    pub fn size(&self) -> usize {
+        self.shape().iter().product::<i64>() as usize * self.kind().size()
+    }
 }
 
-impl Tensor {
-    fn set_data(&self, data: &[u8]) -> Result<(), Error> {
-        let inner = unsafe { &mut *self.ptr };
-        let numel = inner.ne.iter().product::<i64>() as usize;
-        let inner_size = unsafe { ggml_type_size(inner.type_) * numel };
-        if data.len() != inner_size {
-            return Err(Error::DimensionMismatch(data.len(), inner_size));
-        }
-        unsafe {
-            inner
-                .data
-                .copy_from_nonoverlapping(data.as_ptr() as _, data.len())
+pub struct SharedTensor(TensorNode);
+
+#[derive(Debug, Clone)]
+pub struct TensorNode {
+    inner: Rc<Tensor>,
+    _deps: Vec<TensorNode>,
+}
+
+impl TensorNode {
+    pub fn name(&mut self, name: &str) {
+        unsafe { bindings::ggml_set_name(self.inner.ptr, name.as_bytes().as_ptr() as _) };
+    }
+
+    pub fn matmul(&self, other: &Self) -> Self {
+        let tensor = unsafe {
+            bindings::ggml_mul_mat(self.inner.ctx.as_ptr(), self.inner.ptr, other.inner.ptr)
         };
-        Ok(())
+        Self::new_with_data_alloc(self.inner.ctx, tensor, &[self.clone(), other.clone()])
     }
 
-    fn get_data(&self) -> &[u8] {
-        let inner = unsafe { &*self.ptr };
-        let numel = inner.ne.iter().product::<i64>() as usize;
-        let inner_size = unsafe { ggml_type_size(inner.type_) * numel };
-        unsafe { std::slice::from_raw_parts(inner.data as *const u8, inner_size) }
+    pub fn mul(&self, other: &Self) -> Self {
+        let tensor =
+            unsafe { bindings::ggml_mul(self.inner.ctx.as_ptr(), self.inner.ptr, other.inner.ptr) };
+        Self::new_with_data_alloc(self.inner.ctx, tensor, &[self.clone(), other.clone()])
+    }
+
+    pub fn mul_inplace(self, other: &Self) -> Result<Self, Error> {
+        if let Ok(inner) = Rc::try_unwrap(self.inner) {
+            let tensor = unsafe {
+                bindings::ggml_mul_inplace(inner.ctx.as_ptr(), inner.ptr, other.inner.ptr)
+            };
+            Ok(Self::new_with_data_set(
+                inner.ctx,
+                tensor,
+                &[other.clone()],
+                inner.data,
+            ))
+        } else {
+            Err(Error::TensorNotOwned)
+        }
+    }
+
+    pub fn silu(&self) -> Self {
+        let tensor = unsafe { bindings::ggml_silu(self.inner.ctx.as_ptr(), self.inner.ptr) };
+        Self::new_with_data_alloc(self.inner.ctx, tensor, std::slice::from_ref(self))
+    }
+
+    pub fn silu_inplace(self) -> Result<Self, Error> {
+        if let Ok(inner) = Rc::try_unwrap(self.inner) {
+            let tensor = unsafe { bindings::ggml_silu_inplace(inner.ctx.as_ptr(), inner.ptr) };
+            Ok(Self::new_with_data_set(inner.ctx, tensor, &[], inner.data))
+        } else {
+            Err(Error::TensorNotOwned)
+        }
+    }
+
+    pub fn transpose(&self) -> Self {
+        let tensor = unsafe { bindings::ggml_transpose(self.inner.ctx.as_ptr(), self.inner.ptr) };
+        let tensor = unsafe { bindings::ggml_cont(self.inner.ctx.as_ptr(), tensor) };
+        Self::new_with_data_alloc(self.inner.ctx, tensor, std::slice::from_ref(self))
+    }
+
+    pub fn cast(&self, kind: Kind) -> Self {
+        let tensor =
+            unsafe { bindings::ggml_cast(self.inner.ctx.as_ptr(), self.inner.ptr, kind as _) };
+        Self::new_with_data_alloc(self.inner.ctx, tensor, std::slice::from_ref(self))
     }
 }
 
-impl Clone for Tensor {
-    fn clone(&self) -> Self {
-        let ptr = unsafe { ggml_dup_tensor(self.ctx.as_ptr(), self.ptr) };
-        Self { ctx: self.ctx, ptr }
+impl TensorNode {
+    fn new_with_data_set(
+        ctx: NonNull<bindings::ggml_context>,
+        ptr: *mut bindings::ggml_tensor,
+        deps: &[TensorNode],
+        data: Option<Pin<Box<[u8]>>>,
+    ) -> Self {
+        let mut tensor = Tensor {
+            ctx,
+            ptr,
+            data: None,
+        };
+
+        if let Some(data) = &data {
+            unsafe { (*ptr).data = data.as_ptr() as _ };
+        }
+
+        tensor.data = data;
+
+        Self {
+            inner: Rc::new(tensor),
+            _deps: deps.to_vec(),
+        }
+    }
+
+    fn new_with_data_alloc(
+        ctx: NonNull<bindings::ggml_context>,
+        ptr: *mut bindings::ggml_tensor,
+        deps: &[TensorNode],
+    ) -> Self {
+        let mut tensor = Tensor {
+            ctx,
+            ptr,
+            data: None,
+        };
+
+        let size = tensor.size();
+        let data = Pin::new(vec![0u8; size].into_boxed_slice());
+
+        unsafe { (*ptr).data = data.as_ptr() as _ };
+
+        tensor.data = Some(data);
+
+        Self {
+            inner: Rc::new(tensor),
+            _deps: deps.to_vec(),
+        }
     }
 }
 
-unsafe impl Send for Tensor {}
+impl std::ops::Deref for TensorNode {
+    type Target = Tensor;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum Error {
     DimensionMismatch(usize, usize),
+    InputTensorDataFound,
+    OutputTensorDataNotFound,
+    TensorNotOwned,
 }
 
 impl std::error::Error for Error {}
@@ -365,6 +374,15 @@ impl std::fmt::Display for Error {
         match self {
             Error::DimensionMismatch(got, expected) => {
                 write!(f, "Dimension mismatch: got {}, expected {}", got, expected)
+            }
+            Error::InputTensorDataFound => {
+                write!(f, "Input tensor data found")
+            }
+            Error::OutputTensorDataNotFound => {
+                write!(f, "Output tensor data not found")
+            }
+            Error::TensorNotOwned => {
+                write!(f, "Tensor is not owned")
             }
         }
     }
@@ -399,12 +417,16 @@ mod test {
 
         let expected_c = matmul(&a, &b);
 
-        let mut graph = ctx.create_graph(|allocator| {
-            let tensor_a = allocator.alloc(&[3, 1], Kind::F32);
-            let tensor_b = allocator.alloc(&[3, 1], Kind::F32);
-            let tensor_c = tensor_a.matmul(&tensor_b);
-            ([tensor_a, tensor_b], tensor_c)
-        });
+        let mut graph = ctx
+            .create_graph(|allocator| {
+                let tensor_a = allocator.alloc(&[3, 1], Kind::F32);
+                let tensor_b = allocator.alloc(&[3, 1], Kind::F32);
+                let tmp = tensor_a.matmul(&tensor_b);
+                let tmp = tmp.transpose();
+                let tmp = tmp.transpose();
+                Ok(([tensor_a, tensor_b], tmp))
+            })
+            .unwrap();
 
         let inputs_shape = graph.inputs_shape();
         let output_shape = graph.output_shape();

--- a/ek-ggml/src/core.rs
+++ b/ek-ggml/src/core.rs
@@ -251,7 +251,7 @@ impl Tensor {
 
 impl Clone for Tensor {
     fn clone(&self) -> Self {
-        let ptr = unsafe { ggml_dup_tensor(self.ctx.as_ptr(), &mut *self.ptr) };
+        let ptr = unsafe { ggml_dup_tensor(self.ctx.as_ptr(), self.ptr) };
         Self { ctx: self.ctx, ptr }
     }
 }
@@ -264,9 +264,9 @@ mod test {
 
     fn matmul<const N: usize>(a: &[f32; N], b: &[f32; N]) -> Vec<f32> {
         let mut c = Vec::with_capacity(N * N); // C^T = A * B^T
-        for j in 0..N {
-            for i in 0..N {
-                c.push(a[i] * b[j]);
+        for &j in b.iter().take(N) {
+            for &i in a.iter().take(N) {
+                c.push(i * j);
             }
         }
         c
@@ -274,10 +274,7 @@ mod test {
 
     fn set_tensor(tensor: &mut Tensor, data: &[f32]) {
         let tensor_data = unsafe {
-            std::slice::from_raw_parts_mut(
-                data.as_ptr() as *mut _,
-                data.len() * std::mem::size_of::<f32>(),
-            )
+            std::slice::from_raw_parts_mut(data.as_ptr() as *mut _, std::mem::size_of_val(data))
         };
         tensor.set_data(tensor_data).unwrap();
     }
@@ -308,11 +305,11 @@ mod test {
         assert_eq!(tensor_a.shape(), &[3, 1]);
         assert_eq!(tensor_b.shape(), &[3, 1]);
 
-        let mut tensor_c = tensor_a.matmul(&mut tensor_b);
+        let tensor_c = tensor_a.matmul(&tensor_b);
 
         let mut graph = ctx.create_graph();
 
-        graph.build_forward(&mut tensor_c);
+        graph.build_forward(&tensor_c);
 
         set_tensor(&mut tensor_a, &a);
         set_tensor(&mut tensor_b, &b);

--- a/ek-ggml/src/core.rs
+++ b/ek-ggml/src/core.rs
@@ -1,7 +1,5 @@
 use std::{pin::Pin, ptr::NonNull, rc::Rc};
 
-use crate::bindings::{ggml_graph_print, ggml_n_dims, ggml_tensor_overhead};
-
 #[allow(warnings)]
 pub(crate) mod bindings {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
@@ -136,9 +134,7 @@ impl<const N: usize> Graph<N> {
     }
 
     pub fn print(&self) {
-        unsafe {
-            ggml_graph_print(self.ptr.as_ptr());
-        }
+        unsafe { bindings::ggml_graph_print(self.ptr.as_ptr()) };
     }
 }
 
@@ -212,7 +208,7 @@ pub struct Tensor {
 impl Tensor {
     #[inline]
     pub fn overhead() -> usize {
-        unsafe { ggml_tensor_overhead() }
+        unsafe { bindings::ggml_tensor_overhead() }
     }
 
     pub fn kind(&self) -> Kind {
@@ -221,7 +217,7 @@ impl Tensor {
     }
 
     pub fn shape(&self) -> Vec<i64> {
-        let n_dim = unsafe { ggml_n_dims(self.ptr) };
+        let n_dim = unsafe { bindings::ggml_n_dims(self.ptr) };
         let inner = unsafe { &*self.ptr };
         inner.ne.iter().take(n_dim as _).rev().cloned().collect()
     }

--- a/ek-ggml/src/core.rs
+++ b/ek-ggml/src/core.rs
@@ -1,6 +1,6 @@
-use std::{cell::OnceCell, ptr::NonNull};
+use std::ptr::NonNull;
 
-use crate::bindings::{ggml_dup_tensor, ggml_n_dims, ggml_type_size};
+use crate::bindings::{ggml_dup_tensor, ggml_n_dims, ggml_tensor_overhead, ggml_type_size};
 
 #[allow(warnings)]
 pub(crate) mod bindings {
@@ -12,18 +12,8 @@ pub struct Context {
     ptr: NonNull<bindings::ggml_context>,
 }
 
-thread_local! {
-    static CONTEXT: OnceCell<Context> = OnceCell::new();
-}
-
 impl Context {
-    pub fn init(size: usize) {
-        CONTEXT.with(|ctx| {
-            ctx.get_or_init(|| Context::new(size));
-        });
-    }
-
-    fn new(size: usize) -> Self {
+    pub fn new(size: usize) -> Self {
         let params = bindings::ggml_init_params {
             mem_buffer: std::ptr::null_mut(),
             mem_size: size,
@@ -34,6 +24,31 @@ impl Context {
 
         Self {
             ptr: NonNull::new(ctx).unwrap(),
+        }
+    }
+
+    pub fn create_graph(&mut self) -> Graph {
+        let graph = unsafe { bindings::ggml_new_graph(self.ptr.as_ptr()) };
+
+        Graph {
+            ctx: NonNull::new(self.ptr.as_ptr()).unwrap(),
+            ptr: NonNull::new(graph).unwrap(),
+        }
+    }
+
+    pub fn create_tensor(&mut self, shape: &[i64], kind: Kind) -> Tensor {
+        let ne = shape.iter().rev().cloned().collect::<Vec<_>>();
+        let tensor = unsafe {
+            bindings::ggml_new_tensor(
+                self.ptr.as_ptr(),
+                kind as _,
+                ne.len() as _,
+                ne.as_ptr() as _,
+            )
+        };
+        Tensor {
+            ctx: NonNull::new(self.ptr.as_ptr()).unwrap(),
+            ptr: tensor,
         }
     }
 }
@@ -52,16 +67,8 @@ pub struct Graph {
 }
 
 impl Graph {
-    pub fn new() -> Self {
-        CONTEXT.with(|ctx| {
-            let ctx = ctx.get().expect("Context not initialized");
-            let graph = unsafe { bindings::ggml_new_graph(ctx.ptr.as_ptr()) };
-
-            Self {
-                ctx: NonNull::new(ctx.ptr.as_ptr()).unwrap(),
-                ptr: NonNull::new(graph).unwrap(),
-            }
-        })
+    pub fn overhead() -> usize {
+        unsafe { bindings::ggml_graph_overhead() }
     }
 
     pub fn build_forward(&mut self, tensor: &Tensor) {
@@ -85,9 +92,11 @@ unsafe impl Send for Graph {}
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Kind {
     F32 = bindings::ggml_type_GGML_TYPE_F32,
+    BF16 = bindings::ggml_type_GGML_TYPE_BF16,
 }
 
 impl Kind {
+    #[inline]
     pub fn size(&self) -> usize {
         let ggml_type: bindings::ggml_type = *self as _;
         unsafe { bindings::ggml_type_size(ggml_type) }
@@ -95,9 +104,11 @@ impl Kind {
 }
 
 impl From<bindings::ggml_type> for Kind {
+    #[inline]
     fn from(ggml_type: bindings::ggml_type) -> Self {
         match ggml_type {
             bindings::ggml_type_GGML_TYPE_F32 => Kind::F32,
+            bindings::ggml_type_GGML_TYPE_BF16 => Kind::BF16,
             _ => unreachable!(),
         }
     }
@@ -110,49 +121,9 @@ pub struct Tensor {
 }
 
 impl Tensor {
-    pub fn empty(shape: &[i64], kind: Kind) -> Option<Self> {
-        CONTEXT.with(|ctx| {
-            let ctx = ctx.get().expect("Context not initialized");
-            let ne: Vec<i64> = shape.iter().rev().cloned().collect();
-            let tensor = unsafe {
-                bindings::ggml_new_tensor(
-                    ctx.ptr.as_ptr(),
-                    kind as _,
-                    ne.len() as _,
-                    ne.as_ptr() as _,
-                )
-            };
-            Some(Self {
-                ctx: NonNull::new(ctx.ptr.as_ptr())?,
-                ptr: tensor,
-            })
-        })
-    }
-
-    pub unsafe fn from_raw(data: &[u8], shape: &[i64], kind: Kind) -> Option<Self> {
-        CONTEXT.with(|ctx| {
-            let ctx = ctx.get().expect("Context not initialized");
-            let ne: Vec<i64> = shape.iter().rev().cloned().collect();
-            let tensor = unsafe {
-                &mut *bindings::ggml_new_tensor(
-                    ctx.ptr.as_ptr(),
-                    kind as _,
-                    ne.len() as _,
-                    ne.as_ptr() as *const _,
-                )
-            };
-
-            unsafe {
-                tensor
-                    .data
-                    .copy_from_nonoverlapping(data.as_ptr() as _, data.len())
-            };
-
-            Some(Self {
-                ctx: NonNull::new(ctx.ptr.as_ptr()).unwrap(),
-                ptr: tensor,
-            })
-        })
+    #[inline]
+    pub fn overhead() -> usize {
+        unsafe { ggml_tensor_overhead() }
     }
 
     pub fn set_data(&mut self, data: &[u8]) -> Result<(), (usize, usize)> {
@@ -170,18 +141,18 @@ impl Tensor {
         Ok(())
     }
 
-    pub fn shape(&self) -> Vec<i64> {
-        let n_dim = unsafe { ggml_n_dims(self.ptr) };
-        let inner = unsafe { &*self.ptr };
-        inner.ne.iter().take(n_dim as _).rev().cloned().collect()
-    }
-
-    pub fn raw_data(&self) -> &[u8] {
+    pub fn get_data(&self) -> &[u8] {
         let inner = unsafe { &*self.ptr };
         let numel = inner.ne.iter().product::<i64>() as usize;
         unsafe {
             std::slice::from_raw_parts(inner.data as *const u8, ggml_type_size(inner.type_) * numel)
         }
+    }
+
+    pub fn shape(&self) -> Vec<i64> {
+        let n_dim = unsafe { ggml_n_dims(self.ptr) };
+        let inner = unsafe { &*self.ptr };
+        inner.ne.iter().take(n_dim as _).rev().cloned().collect()
     }
 
     pub fn matmul(&self, other: &Tensor) -> Tensor {
@@ -196,6 +167,16 @@ impl Tensor {
     pub fn mul(&self, other: &Tensor) -> Tensor {
         let tensor =
             unsafe { bindings::ggml_mul(self.ctx.as_ptr(), &mut *self.ptr, &mut *other.ptr) };
+        Self {
+            ctx: self.ctx,
+            ptr: tensor,
+        }
+    }
+
+    pub fn mul_inplace(self, other: &Tensor) -> Tensor {
+        let tensor = unsafe {
+            bindings::ggml_mul_inplace(self.ctx.as_ptr(), &mut *self.ptr, &mut *other.ptr)
+        };
         Self {
             ctx: self.ctx,
             ptr: tensor,
@@ -220,6 +201,14 @@ impl Tensor {
     }
     pub fn silu(&self) -> Tensor {
         let tensor = unsafe { bindings::ggml_silu(self.ctx.as_ptr(), &mut *self.ptr) };
+        Self {
+            ctx: self.ctx,
+            ptr: tensor,
+        }
+    }
+
+    pub fn silu_inplace(self) -> Tensor {
+        let tensor = unsafe { bindings::ggml_silu_inplace(self.ctx.as_ptr(), &mut *self.ptr) };
         Self {
             ctx: self.ctx,
             ptr: tensor,
@@ -283,45 +272,54 @@ mod test {
         c
     }
 
-    fn tensor(a: &[f32]) -> Tensor {
-        let len = a.len();
-        let a = unsafe {
+    fn set_tensor(tensor: &mut Tensor, data: &[f32]) {
+        let tensor_data = unsafe {
             std::slice::from_raw_parts_mut(
-                a.as_ptr() as *mut _,
-                a.len() * std::mem::size_of::<f32>(),
+                data.as_ptr() as *mut _,
+                data.len() * std::mem::size_of::<f32>(),
             )
         };
-        unsafe { Tensor::from_raw(a, &[len as _, 1], Kind::F32).unwrap() }
+        tensor.set_data(tensor_data).unwrap();
+    }
+
+    fn chk_tensor(tensor: &Tensor, data: &[f32]) {
+        let tensor_data = tensor.get_data();
+        let result = unsafe {
+            std::slice::from_raw_parts_mut(
+                tensor_data.as_ptr() as *mut f32,
+                tensor_data.len() / std::mem::size_of::<f32>(),
+            )
+        };
+        assert_eq!(result, data);
     }
 
     #[test]
     fn test_tensor_mul() -> Result<(), Box<dyn std::error::Error>> {
-        Context::init(1024 * 1024);
+        let mut ctx = Context::new(1024 * 1024);
 
         let a: [f32; 3] = [1.0, 2.0, 3.0];
         let b: [f32; 3] = [4.0, 5.0, 6.0];
 
         let expected_c = matmul(&a, &b);
 
-        let mut tensor_a = tensor(&a);
-        let mut tensor_b = tensor(&b);
+        let mut tensor_a = ctx.create_tensor(&[3, 1], Kind::F32);
+        let mut tensor_b = ctx.create_tensor(&[3, 1], Kind::F32);
 
         assert_eq!(tensor_a.shape(), &[3, 1]);
         assert_eq!(tensor_b.shape(), &[3, 1]);
+
         let mut tensor_c = tensor_a.matmul(&mut tensor_b);
 
-        let mut graph = Graph::new();
-        graph.build_forward(&mut tensor_c);
-        graph.compute(1);
-        let c_data = tensor_c.raw_data();
-        let result = unsafe {
-            std::slice::from_raw_parts_mut(
-                c_data.as_ptr() as *mut f32,
-                c_data.len() / std::mem::size_of::<f32>(),
-            )
-        };
+        let mut graph = ctx.create_graph();
 
-        assert_eq!(result, &expected_c);
+        graph.build_forward(&mut tensor_c);
+
+        set_tensor(&mut tensor_a, &a);
+        set_tensor(&mut tensor_b, &b);
+
+        graph.compute(1);
+
+        chk_tensor(&tensor_c, &expected_c);
 
         for _ in 0..32 {
             let mut a: [f32; 3] = [0.0; 3];
@@ -333,32 +331,12 @@ mod test {
 
             let expected_c = matmul(&a, &b);
 
-            let a = unsafe {
-                std::slice::from_raw_parts_mut(
-                    a.as_ptr() as _,
-                    a.len() * std::mem::size_of::<f32>(),
-                )
-            };
-            let b = unsafe {
-                std::slice::from_raw_parts_mut(
-                    b.as_ptr() as _,
-                    b.len() * std::mem::size_of::<f32>(),
-                )
-            };
-
-            tensor_a.set_data(a).unwrap();
-            tensor_b.set_data(b).unwrap();
+            set_tensor(&mut tensor_a, &a);
+            set_tensor(&mut tensor_b, &b);
 
             graph.compute(1);
-            let c_data = tensor_c.raw_data();
-            let result = unsafe {
-                std::slice::from_raw_parts_mut(
-                    c_data.as_ptr() as *mut f32,
-                    c_data.len() / std::mem::size_of::<f32>(),
-                )
-            };
 
-            assert_eq!(result, &expected_c);
+            chk_tensor(&tensor_c, &expected_c);
         }
 
         Ok(())

--- a/ek-ggml/src/core.rs
+++ b/ek-ggml/src/core.rs
@@ -155,7 +155,7 @@ impl Tensor {
         inner.ne.iter().take(n_dim as _).rev().cloned().collect()
     }
 
-    pub fn matmul(&self, other: &Tensor) -> Tensor {
+    pub fn matmul(&self, other: &Self) -> Self {
         let tensor =
             unsafe { bindings::ggml_mul_mat(self.ctx.as_ptr(), &mut *self.ptr, &mut *other.ptr) };
         Self {
@@ -164,7 +164,7 @@ impl Tensor {
         }
     }
 
-    pub fn mul(&self, other: &Tensor) -> Tensor {
+    pub fn mul(&self, other: &Self) -> Self {
         let tensor =
             unsafe { bindings::ggml_mul(self.ctx.as_ptr(), &mut *self.ptr, &mut *other.ptr) };
         Self {
@@ -173,7 +173,7 @@ impl Tensor {
         }
     }
 
-    pub fn mul_inplace(self, other: &Tensor) -> Tensor {
+    pub fn mul_inplace(self, other: &Self) -> Self {
         let tensor = unsafe {
             bindings::ggml_mul_inplace(self.ctx.as_ptr(), &mut *self.ptr, &mut *other.ptr)
         };
@@ -183,7 +183,7 @@ impl Tensor {
         }
     }
 
-    pub fn sub(&self, other: &Tensor) -> Tensor {
+    pub fn sub(&self, other: &Self) -> Self {
         let tensor =
             unsafe { bindings::ggml_sub(self.ctx.as_ptr(), &mut *self.ptr, &mut *other.ptr) };
         Self {
@@ -192,14 +192,14 @@ impl Tensor {
         }
     }
 
-    pub fn sum(&self) -> Tensor {
+    pub fn sum(&self) -> Self {
         let tensor = unsafe { bindings::ggml_sum(self.ctx.as_ptr(), &mut *self.ptr) };
         Self {
             ctx: self.ctx,
             ptr: tensor,
         }
     }
-    pub fn silu(&self) -> Tensor {
+    pub fn silu(&self) -> Self {
         let tensor = unsafe { bindings::ggml_silu(self.ctx.as_ptr(), &mut *self.ptr) };
         Self {
             ctx: self.ctx,
@@ -207,7 +207,7 @@ impl Tensor {
         }
     }
 
-    pub fn silu_inplace(self) -> Tensor {
+    pub fn silu_inplace(self) -> Self {
         let tensor = unsafe { bindings::ggml_silu_inplace(self.ctx.as_ptr(), &mut *self.ptr) };
         Self {
             ctx: self.ctx,
@@ -215,11 +215,11 @@ impl Tensor {
         }
     }
 
-    pub fn transpose(&self) -> Tensor {
+    pub fn transpose(&self) -> Self {
         self.transpose_view().cont()
     }
 
-    pub fn transpose_view(&self) -> Tensor {
+    pub fn transpose_view(&self) -> Self {
         let tensor = unsafe { bindings::ggml_transpose(self.ctx.as_ptr(), &mut *self.ptr) };
         Self {
             ctx: self.ctx,
@@ -227,7 +227,7 @@ impl Tensor {
         }
     }
 
-    pub fn cont(&self) -> Tensor {
+    pub fn cont(&self) -> Self {
         let tensor = unsafe { bindings::ggml_cont(self.ctx.as_ptr(), &mut *self.ptr) };
         Self {
             ctx: self.ctx,
@@ -235,7 +235,7 @@ impl Tensor {
         }
     }
 
-    pub fn cast(&self, kind: Kind) -> Tensor {
+    pub fn cast(&self, kind: Kind) -> Self {
         let tensor = unsafe { bindings::ggml_cast(self.ctx.as_ptr(), &mut *self.ptr, kind as _) };
         Self {
             ctx: self.ctx,

--- a/ek-ggml/src/lib.rs
+++ b/ek-ggml/src/lib.rs
@@ -1,0 +1,3 @@
+mod core;
+
+pub use core::*;


### PR DESCRIPTION
TODO:
- [x] End-to-End test

Micro-benchmark (FFN) results:

<img width="5960" height="1750" alt="图片" src="https://github.com/user-attachments/assets/0918cca2-f104-4eb7-b60c-5a9a5f468bf1" />

End-to-End benchmark results:

<img width="2444" height="1086" alt="图片" src="https://github.com/user-attachments/assets/cc3d464d-6b3e-43bc-8a1f-0d60dd58056a" />
