### PR TITLE
perf: balance requests on multiple worker channels

### DIFF
--- a/ek-computation/src/controller/executor.rs
+++ b/ek-computation/src/controller/executor.rs
@@ -50,19 +50,49 @@ struct EgressMeta {
     expert_idx: usize,
 }
 
-pub(crate) enum ForwardResponse {
+pub(crate) struct ForwardResponse {
+    inner: ForwardResponseInner,
+    duration: std::time::Duration,
+}
+
+pub(crate) enum ForwardResponseInner {
     Grpc(v1::ForwardResp),
     Shm(ShmqWorkerResp),
     Rdma(ShmqWorkerResp),
 }
 
 impl ForwardResponse {
-    fn output_tensor(&self) -> &[u8] {
-        match self {
-            ForwardResponse::Grpc(resp) => &resp.output_tensor,
-            ForwardResponse::Shm(resp) => resp.output_tensor(),
-            ForwardResponse::Rdma(resp) => resp.output_tensor(),
+    pub fn grpc(resp: v1::ForwardResp, duration: std::time::Duration) -> Self {
+        Self {
+            inner: ForwardResponseInner::Grpc(resp),
+            duration,
         }
+    }
+
+    pub fn shm(resp: ShmqWorkerResp, duration: std::time::Duration) -> Self {
+        Self {
+            inner: ForwardResponseInner::Shm(resp),
+            duration,
+        }
+    }
+
+    pub fn rdma(resp: ShmqWorkerResp, duration: std::time::Duration) -> Self {
+        Self {
+            inner: ForwardResponseInner::Rdma(resp),
+            duration,
+        }
+    }
+
+    fn output_tensor(&self) -> &[u8] {
+        match &self.inner {
+            ForwardResponseInner::Grpc(resp) => &resp.output_tensor,
+            ForwardResponseInner::Shm(resp) => resp.output_tensor(),
+            ForwardResponseInner::Rdma(resp) => resp.output_tensor(),
+        }
+    }
+
+    fn duration(&self) -> std::time::Duration {
+        self.duration
     }
 }
 
@@ -188,6 +218,7 @@ impl NaiveExecutor {
                 .collect::<Vec<GlobalSeqId>>();
 
             let egress_tensor = self.assemble_seq_tensors(seq_gids)?;
+            let egress_tensor_bat = egress_tensor.size()[0];
             log::debug!("egress tensor shape={:?}", egress_tensor.size());
             let seqs = egress_meta
                 .iter()
@@ -196,31 +227,61 @@ impl NaiveExecutor {
                 })
                 .collect::<Vec<_>>();
 
-            let clients_count = clients.len() as i64;
-            let tensors = egress_tensor.chunk(clients_count, 0);
+            let mut client_priorities = vec![];
+            let mut client_priorities_sum = 0.0;
+            for cli in &clients {
+                let p = cli.get_priority().await;
+                client_priorities.push(p);
+                client_priorities_sum += p;
+            }
+            for p in &mut client_priorities {
+                *p /= client_priorities_sum;
+            }
+            let mut splits = Vec::with_capacity(client_priorities.len());
+            let mut acc = 0;
+            for (i, &r) in client_priorities.iter().enumerate() {
+                if i == client_priorities.len() - 1 {
+                    splits.push(egress_tensor_bat - acc);
+                } else {
+                    let size = (r * egress_tensor_bat as f64).round() as i64;
+                    splits.push(size);
+                    acc += size;
+                }
+            }
+
+            log::debug!("split egress_tensor with sizes={splits:?}");
+            let tensors = egress_tensor.split_with_sizes(splits, 0);
 
             let mut handle_lst = vec![];
+            let clients_count = clients.len();
             for (client, tensor) in clients.into_iter().zip(tensors) {
+                if tensor.size()[0] == 0 {
+                    continue;
+                }
                 let pending_resp = self.pending_resp.clone();
                 let expert_id = expert_id.to_owned();
                 log::debug!("forward tensor shape={:?}", tensor.size());
-                let handle = client.forward(
+                let handle = client.clone().forward(
                     expert_id,
                     TchTensor::from(tensor).serialize(),
                     seqs.clone(),
                     pending_resp,
                 );
-                handle_lst.push(handle);
+                handle_lst.push((handle, client));
             }
-            handles.push(handle_lst);
+            handles.push((clients_count, handle_lst));
         }
 
         tit.stop("egress_req_sent");
 
         'outer: for (egress_idx, handles) in handles.into_iter().enumerate() {
             let egress = &chips[egress_idx];
+            let (clients_count, handles) = handles;
+            let handles_count = handles.len();
+            let mut clients = vec![];
+            let mut res_duration = vec![];
             let mut res_tensors = vec![];
-            for handle in handles {
+            for (handle, client) in handles {
                 let Ok(res) = handle.await? else {
                     log::error!("failed to receive response for expert {}", egress.0);
                     continue 'outer;
@@ -229,8 +290,28 @@ impl NaiveExecutor {
                 // TODO: hardcode safe tensor name
                 let view = res_safetensor.tensor("data")?;
                 let res_tensor = TchTensor::from(&view).inner();
+                if clients_count == handles_count {
+                    let batch = res_tensor.size()[0];
+                    clients.push(client);
+                    res_duration.push((res.duration(), batch));
+                }
                 res_tensors.push(res_tensor);
             }
+            if clients_count == handles_count {
+                let per_batch_duration = res_duration
+                    .iter()
+                    .map(|&(d, b)| d.as_micros() / b as u128)
+                    .collect::<Vec<_>>();
+                let sum_of_duration = per_batch_duration.iter().sum::<u128>() as f64;
+                let cli_priority_delta = per_batch_duration
+                    .into_iter()
+                    .map(|d| 1.0 - d as f64 / sum_of_duration);
+                for (cli, delta) in clients.iter().zip(cli_priority_delta) {
+                    log::debug!("expert client priority update: delta={delta}");
+                    cli.update_priority(delta).await;
+                }
+            }
+
             let res_tensor = Tensor::cat(&res_tensors, 0);
 
             log::debug!("received tensor shape={:?}", res_tensor.size());

--- a/ek-computation/src/controller/executor.rs
+++ b/ek-computation/src/controller/executor.rs
@@ -2,24 +2,21 @@ use std::{
     collections::{BTreeMap, HashMap},
     fmt,
     sync::{Arc, OnceLock},
-    time,
 };
 
 use ek_base::{
-    config::get_ek_settings,
     error::{EKError, EKResult},
-    utils::{Defers, PerfTimer},
+    utils::PerfTimer,
 };
 use safetensors::SafeTensors;
 use tch::{IndexOp, Tensor};
 use tokio::sync::{Mutex, mpsc};
-use tracing::{Instrument, instrument, span};
+use tracing::{instrument, span};
 
 use crate::{
     backend::{EkTensor, torch::TchTensor},
-    controller::registry::{ExpertClient, ExpertId, ExpertIdRef, ShmqWorkerReq, ShmqWorkerResp},
-    metrics::METRIC_CONTROLLER_INTRA_REQ,
-    proto::ek::worker::v1::{self},
+    controller::registry::{ExpertId, ExpertIdRef, ShmqWorkerResp},
+    proto::ek::worker::v1,
 };
 
 use super::registry::{GlobalWorkerRegistry, get_registry};
@@ -53,7 +50,7 @@ struct EgressMeta {
     expert_idx: usize,
 }
 
-enum ForwardResponse {
+pub(crate) enum ForwardResponse {
     Grpc(v1::ForwardResp),
     Shm(ShmqWorkerResp),
     Rdma(ShmqWorkerResp),
@@ -70,25 +67,9 @@ impl ForwardResponse {
 }
 
 #[derive(Debug, Clone)]
-enum PendingResponse {
+pub(crate) enum PendingResponse {
     Shm(ShmqWorkerResp),
     Rdma(ShmqWorkerResp),
-}
-
-impl PendingResponse {
-    fn into_shm(self) -> Option<ShmqWorkerResp> {
-        match self {
-            PendingResponse::Shm(resp) => Some(resp),
-            PendingResponse::Rdma(_) => None,
-        }
-    }
-
-    fn into_rdma(self) -> Option<ShmqWorkerResp> {
-        match self {
-            PendingResponse::Shm(_) => None,
-            PendingResponse::Rdma(resp) => Some(resp),
-        }
-    }
 }
 
 pub struct NaiveExecutor {
@@ -192,11 +173,10 @@ impl NaiveExecutor {
         let mut tit = PerfTimer::new("inner_execute");
         let mut handles = vec![];
         let mut chips: Vec<(ExpertId, Vec<EgressMeta>)> = vec![];
-        let settings = get_ek_settings();
 
         while let Some((expert_id, egress_meta)) = self.pending_egress.pop_first() {
             let expert_id: ExpertIdRef = expert_id.as_ref();
-            let Ok(client) = self.registry.lock().await.select(expert_id).await else {
+            let Ok(clients) = self.registry.lock().await.select_all(expert_id).await else {
                 log::warn!("failed to select client for expert {expert_id}");
                 continue;
             };
@@ -209,7 +189,6 @@ impl NaiveExecutor {
 
             let egress_tensor = self.assemble_seq_tensors(seq_gids)?;
             log::debug!("egress tensor shape={:?}", egress_tensor.size());
-            let serialized_tensor = TchTensor::from(egress_tensor).serialize();
             let seqs = egress_meta
                 .iter()
                 .map(|_e| v1::forward_req::SequenceInfo {
@@ -217,167 +196,42 @@ impl NaiveExecutor {
                 })
                 .collect::<Vec<_>>();
 
-            let pending_resp = self.pending_resp.clone();
-            let expert_id = expert_id.to_owned();
-            match client {
-                ExpertClient::Grpc(grpc_channel) => {
-                    let mut cli =
-                        v1::computation_service_client::ComputationServiceClient::new(grpc_channel)
-                            .max_decoding_message_size(1024 * 1024 * 1024)
-                            .max_encoding_message_size(1024 * 1024 * 1024);
+            let clients_count = clients.len() as i64;
+            let tensors = egress_tensor.chunk(clients_count, 0);
 
-                    let f = tokio::spawn(
-                        async move {
-                            let req = v1::ForwardReq {
-                                // TODO: hardcode instance id.
-                                instance_id: "0".into(),
-                                tensor: serialized_tensor,
-                                sequences: seqs,
-                            };
-
-                            let start = time::Instant::now();
-                            let _d = Defers::defer(Box::new(move || {
-                                let elapsed = start.elapsed();
-                                // TODO: hardcode metric name
-                                METRIC_CONTROLLER_INTRA_REQ
-                                    .with_label_values(&[settings.inference.model_name.as_str()])
-                                    .observe(elapsed.as_micros() as f64);
-                            }));
-                            cli.forward(req)
-                                .await
-                                .map(|resp| ForwardResponse::Grpc(resp.into_inner()))
-                                .map_err(|e| log::error!("forward error: {e}"))
-                        }
-                        .in_current_span(),
-                    );
-                    handles.push(f);
-                }
-                ExpertClient::Shm((send_channel, recv_channel)) => {
-                    let fu = async move {
-                        let req = ShmqWorkerReq::new(expert_id.as_ref(), &serialized_tensor);
-
-                        let start = time::Instant::now();
-                        let _d = Defers::defer(Box::new(move || {
-                            let elapsed = start.elapsed();
-                            // TODO: hardcode metric name
-                            METRIC_CONTROLLER_INTRA_REQ
-                                .with_label_values(&[settings.inference.model_name.as_str()])
-                                .observe(elapsed.as_micros() as f64);
-                        }));
-
-                        while send_channel.lock().await.send(&req).is_err() {
-                            log::warn!("failed to send request to expert {expert_id}");
-                            tokio::time::sleep(tokio::time::Duration::from_micros(100)).await;
-                        }
-
-                        log::debug!(
-                            "request sent for expert {}, waiting for response",
-                            expert_id
-                        );
-                        let resp = loop {
-                            if let Some(pending_resp) = pending_resp.lock().await.remove(&req.id())
-                                && let Some(resp) = pending_resp.into_shm()
-                            {
-                                break resp;
-                            }
-                            match recv_channel.lock().await.recv() {
-                                Ok(resp) => {
-                                    if resp.id() != req.id() {
-                                        log::debug!(
-                                            "received response for expert {} but id not correct",
-                                            expert_id
-                                        );
-                                        pending_resp
-                                            .lock()
-                                            .await
-                                            .insert(resp.id(), PendingResponse::Shm(resp));
-                                        tokio::task::yield_now().await;
-                                        continue;
-                                    }
-                                    break resp;
-                                }
-                                Err(_) => {
-                                    tokio::task::yield_now().await;
-                                }
-                            }
-                        };
-                        Ok(ForwardResponse::Shm(resp))
-                    }
-                    .in_current_span();
-                    handles.push(tokio::spawn(fu));
-                }
-                ExpertClient::Rdma((send_channel, recv_channel)) => {
-                    let fu = async move {
-                        let req = ShmqWorkerReq::new(expert_id.as_ref(), &serialized_tensor);
-
-                        let start = time::Instant::now();
-                        let _d = Defers::defer(Box::new(move || {
-                            let elapsed = start.elapsed();
-                            METRIC_CONTROLLER_INTRA_REQ
-                                .with_label_values(&[settings.inference.model_name.as_str()])
-                                .observe(elapsed.as_micros() as f64);
-                        }));
-
-                        // Send request via RDMA
-                        loop {
-                           match send_channel.lock().await.send(&req) {
-                                Ok(_) => break,
-                                Err(e) => {
-                                    log::warn!("failed to send RDMA request to expert {expert_id}: {e}");
-                                    tokio::time::sleep(tokio::time::Duration::from_micros(100)).await;
-                                }
-                            }
-                        }
-
-                        log::debug!(
-                            "RDMA request sent for expert {}, waiting for response",
-                            expert_id
-                        );
-
-                        // Wait for response via RDMA
-                        let resp = loop {
-                            if let Some(pending_resp) = pending_resp.lock().await.remove(&req.id())
-                                && let Some(resp) = pending_resp.into_rdma() {
-                                    break resp;
-                                }
-                            match recv_channel.lock().await.recv() {
-                                Ok(resp) => {
-                                    if resp.id() != req.id() {
-                                        log::debug!(
-                                            "received RDMA response for expert {} but id not correct",
-                                            expert_id
-                                        );
-                                        pending_resp.lock().await.insert(resp.id(), PendingResponse::Rdma(resp));
-                                        tokio::task::yield_now().await;
-                                        continue;
-                                    }
-                                    break resp;
-                                }
-                                Err(_) => {
-                                    tokio::task::yield_now().await;
-                                }
-                            }
-                        };
-                        Ok(ForwardResponse::Rdma(resp))
-                    }
-                    .in_current_span();
-                    handles.push(tokio::spawn(fu));
-                }
+            let mut handle_lst = vec![];
+            for (client, tensor) in clients.into_iter().zip(tensors) {
+                let pending_resp = self.pending_resp.clone();
+                let expert_id = expert_id.to_owned();
+                log::debug!("forward tensor shape={:?}", tensor.size());
+                let handle = client.forward(
+                    expert_id,
+                    TchTensor::from(tensor).serialize(),
+                    seqs.clone(),
+                    pending_resp,
+                );
+                handle_lst.push(handle);
             }
+            handles.push(handle_lst);
         }
 
         tit.stop("egress_req_sent");
 
-        for (egress_idx, handle) in handles.into_iter().enumerate() {
+        'outer: for (egress_idx, handles) in handles.into_iter().enumerate() {
             let egress = &chips[egress_idx];
-            let Ok(res) = handle.await? else {
-                log::error!("failed to receive response for expert {}", egress.0);
-                continue;
-            };
-            let res_safetensor = SafeTensors::deserialize(res.output_tensor())?;
-            // TODO: hardcode safe tensor name
-            let view = res_safetensor.tensor("data")?;
-            let res_tensor = TchTensor::from(&view).inner();
+            let mut res_tensors = vec![];
+            for handle in handles {
+                let Ok(res) = handle.await? else {
+                    log::error!("failed to receive response for expert {}", egress.0);
+                    continue 'outer;
+                };
+                let res_safetensor = SafeTensors::deserialize(res.output_tensor())?;
+                // TODO: hardcode safe tensor name
+                let view = res_safetensor.tensor("data")?;
+                let res_tensor = TchTensor::from(&view).inner();
+                res_tensors.push(res_tensor);
+            }
+            let res_tensor = Tensor::cat(&res_tensors, 0);
 
             log::debug!("received tensor shape={:?}", res_tensor.size());
             for (seq_idx, egress_meta) in egress.1.iter().enumerate() {

--- a/ek-computation/src/controller/registry.rs
+++ b/ek-computation/src/controller/registry.rs
@@ -7,16 +7,22 @@ use std::{
 };
 
 use ek_base::{
+    config::get_ek_settings,
     error::{EKError, EKResult},
     tracing::grpc::OTelGrpcClientMiddleware,
+    utils::Defers,
 };
 use ndarray_rand::rand;
 use serde::{Deserialize, Serialize};
-use tokio::sync::Mutex;
+use tokio::{sync::Mutex, time};
 use tonic::transport::Channel;
 use tower::ServiceBuilder;
+use tracing::Instrument;
 
 use crate::{
+    controller::executor::{ForwardResponse, PendingResponse},
+    metrics::METRIC_CONTROLLER_INTRA_REQ,
+    proto::ek::worker::v1::{self, forward_req::SequenceInfo},
     shmq::{GeneralShmQueueBytes, ShmQueue, rdma_impl::RdmaQueue},
     state::{
         io::{StateReader, StateReaderImpl},
@@ -57,46 +63,243 @@ impl std::fmt::Debug for ExpertClient {
 }
 
 impl ExpertClient {
-    pub fn into_grpc_client(self) -> Option<OTelGrpcClientMiddleware> {
+    pub(crate) fn forward(
+        self,
+        expert_id: ExpertId,
+        tensor: Vec<u8>,
+        sequences: Vec<SequenceInfo>,
+        pending_resp: Arc<Mutex<HashMap<usize, PendingResponse>>>,
+    ) -> tokio::task::JoinHandle<EKResult<ForwardResponse>> {
         match self {
-            ExpertClient::Grpc(client) => Some(client),
-            ExpertClient::Shm(_) => None,
-            ExpertClient::Rdma(_) => None,
+            ExpertClient::Grpc(grpc_channel) => {
+                let mut cli =
+                    v1::computation_service_client::ComputationServiceClient::new(grpc_channel)
+                        .max_decoding_message_size(1024 * 1024 * 1024)
+                        .max_encoding_message_size(1024 * 1024 * 1024);
+
+                let fu = async move {
+                    let req = v1::ForwardReq {
+                        // TODO: hardcode instance id.
+                        instance_id: "0".into(),
+                        tensor,
+                        sequences,
+                    };
+
+                    let _d = Self::create_metrics_defer();
+                    cli.forward(req)
+                        .await
+                        .map(|resp| ForwardResponse::Grpc(resp.into_inner()))
+                        .map_err(|e| {
+                            log::error!("forward error: {e}");
+                            EKError::IoError(std::io::Error::other(format!("grpc error: {e}")))
+                        })
+                }
+                .in_current_span();
+                tokio::task::spawn(fu)
+            }
+            ExpertClient::Shm((send_channel, recv_channel)) => {
+                let fu = async move {
+                    let req = ShmqWorkerReq::new(expert_id.as_ref(), &tensor);
+                    let _d = Self::create_metrics_defer();
+
+                    // Send request with retry
+                    if let Err(e) =
+                        Self::send_shm_request_with_retry(&send_channel, &req, &expert_id).await
+                    {
+                        log::error!("Failed to send SHM request: {e:?}");
+                        return Err(e);
+                    }
+
+                    log::debug!(
+                        "request sent for expert {}, waiting for response",
+                        expert_id
+                    );
+
+                    // Receive response with ID matching
+                    match Self::receive_shm_response(
+                        &recv_channel,
+                        &pending_resp,
+                        req.id(),
+                        &expert_id,
+                    )
+                    .await
+                    {
+                        Ok(resp) => Ok(ForwardResponse::Shm(resp)),
+                        Err(e) => {
+                            log::error!("Failed to receive SHM response: {e:?}");
+                            Err(e)
+                        }
+                    }
+                }
+                .in_current_span();
+                tokio::task::spawn(fu)
+            }
+            ExpertClient::Rdma((send_channel, recv_channel)) => {
+                let fu = async move {
+                    let req = ShmqWorkerReq::new(expert_id.as_ref(), &tensor);
+                    let _d = Self::create_metrics_defer();
+
+                    // Send request with retry
+                    if let Err(e) =
+                        Self::send_rdma_request_with_retry(&send_channel, &req, &expert_id).await
+                    {
+                        log::error!("Failed to send RDMA request: {e:?}");
+                        return Err(e);
+                    }
+
+                    log::debug!(
+                        "RDMA request sent for expert {}, waiting for response",
+                        expert_id
+                    );
+
+                    // Receive response with ID matching
+                    match Self::receive_rdma_response(
+                        &recv_channel,
+                        &pending_resp,
+                        req.id(),
+                        &expert_id,
+                    )
+                    .await
+                    {
+                        Ok(resp) => Ok(ForwardResponse::Rdma(resp)),
+                        Err(e) => {
+                            log::error!("Failed to receive RDMA response: {e:?}");
+                            Err(e)
+                        }
+                    }
+                }
+                .in_current_span();
+                tokio::task::spawn(fu)
+            }
         }
     }
 
-    pub fn into_shm_channels(self) -> Option<LocalShmChannel> {
-        match self {
-            ExpertClient::Grpc(_) => None,
-            ExpertClient::Shm(channels) => Some(channels),
-            ExpertClient::Rdma(_) => None,
+    /// Create a performance timer deferred callback for metrics collection
+    fn create_metrics_defer() -> Defers {
+        let settings = get_ek_settings();
+        let start = time::Instant::now();
+        Defers::defer(Box::new(move || {
+            let elapsed = start.elapsed();
+            METRIC_CONTROLLER_INTRA_REQ
+                .with_label_values(&[settings.inference.model_name.as_str()])
+                .observe(elapsed.as_micros() as f64);
+        }))
+    }
+
+    /// Handle shared memory request sending with retry logic
+    async fn send_shm_request_with_retry(
+        send_channel: &Arc<Mutex<ShmQueue<'static, ShmqWorkerReq>>>,
+        req: &ShmqWorkerReq,
+        expert_id: &str,
+    ) -> EKResult<()> {
+        while send_channel.lock().await.send(req).is_err() {
+            log::warn!("failed to send request to expert {expert_id}");
+            tokio::time::sleep(tokio::time::Duration::from_micros(100)).await;
+        }
+        Ok(())
+    }
+
+    /// Handle RDMA request sending with retry logic
+    async fn send_rdma_request_with_retry(
+        send_channel: &Arc<Mutex<RdmaQueue<ShmqWorkerReq>>>,
+        req: &ShmqWorkerReq,
+        expert_id: &str,
+    ) -> EKResult<()> {
+        loop {
+            match send_channel.lock().await.send(req) {
+                Ok(_) => break,
+                Err(e) => {
+                    log::warn!("failed to send RDMA request to expert {expert_id}: {e}");
+                    tokio::time::sleep(tokio::time::Duration::from_micros(100)).await;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Handle shared memory response reception with ID matching
+    async fn receive_shm_response(
+        recv_channel: &Arc<Mutex<ShmQueue<'static, ShmqWorkerResp>>>,
+        pending_resp: &Arc<Mutex<HashMap<usize, PendingResponse>>>,
+        req_id: usize,
+        expert_id: &str,
+    ) -> EKResult<ShmqWorkerResp> {
+        loop {
+            // Check for pending response first
+            if let Some(pending_resp_item) = pending_resp.lock().await.remove(&req_id)
+                && let PendingResponse::Shm(resp) = pending_resp_item
+            {
+                return Ok(resp);
+            }
+
+            // Receive new response
+            match recv_channel.lock().await.recv() {
+                Ok(resp) => {
+                    if resp.id() != req_id {
+                        log::debug!(
+                            "received response for expert {} but id not correct",
+                            expert_id
+                        );
+                        pending_resp
+                            .lock()
+                            .await
+                            .insert(resp.id(), PendingResponse::Shm(resp));
+                        tokio::task::yield_now().await;
+                        continue;
+                    }
+                    return Ok(resp);
+                }
+                Err(_) => {
+                    tokio::task::yield_now().await;
+                }
+            }
         }
     }
 
-    pub fn into_rdma_channels(self) -> Option<RdmaChannel> {
-        match self {
-            ExpertClient::Grpc(_) => None,
-            ExpertClient::Shm(_) => None,
-            ExpertClient::Rdma(channels) => Some(channels),
+    /// Handle RDMA response reception with ID matching
+    async fn receive_rdma_response(
+        recv_channel: &Arc<Mutex<RdmaQueue<ShmqWorkerResp>>>,
+        pending_resp: &Arc<Mutex<HashMap<usize, PendingResponse>>>,
+        req_id: usize,
+        expert_id: &str,
+    ) -> EKResult<ShmqWorkerResp> {
+        loop {
+            // Check for pending response first
+            if let Some(pending_resp_item) = pending_resp.lock().await.remove(&req_id)
+                && let PendingResponse::Rdma(resp) = pending_resp_item
+            {
+                return Ok(resp);
+            }
+
+            // Receive new response
+            match recv_channel.lock().await.recv() {
+                Ok(resp) => {
+                    if resp.id() != req_id {
+                        log::debug!(
+                            "received RDMA response for expert {} but id not correct",
+                            expert_id
+                        );
+                        pending_resp
+                            .lock()
+                            .await
+                            .insert(resp.id(), PendingResponse::Rdma(resp));
+                        tokio::task::yield_now().await;
+                        continue;
+                    }
+                    return Ok(resp);
+                }
+                Err(_) => {
+                    tokio::task::yield_now().await;
+                }
+            }
         }
-    }
-
-    pub fn is_grpc(&self) -> bool {
-        matches!(self, ExpertClient::Grpc(_))
-    }
-
-    pub fn is_shm(&self) -> bool {
-        matches!(self, ExpertClient::Shm(_))
-    }
-
-    pub fn is_rdma(&self) -> bool {
-        matches!(self, ExpertClient::Rdma(_))
     }
 }
 
 #[async_trait::async_trait]
 pub trait ExpertRegistry {
     async fn select(&mut self, eid: ExpertIdRef<'_>) -> EKResult<ExpertClient>;
+    async fn select_all(&mut self, eid: ExpertIdRef<'_>) -> EKResult<Vec<ExpertClient>>;
     async fn reset(&mut self) -> EKResult<()>;
     async fn deregister(&mut self, host_id: &str);
 }
@@ -147,6 +350,7 @@ impl ExpertRegistry for ExpertRegistryImpl {
     async fn reset(&mut self) -> EKResult<()> {
         self.inner_reset().await
     }
+
     async fn select(&mut self, eid: ExpertIdRef<'_>) -> EKResult<ExpertClient> {
         let ch = self.inner_select(eid).await?;
         match ch {
@@ -160,6 +364,24 @@ impl ExpertRegistry for ExpertRegistryImpl {
             ChannelMeta::Rdma(meta) => Ok(ExpertClient::Rdma(meta.ch.clone())),
         }
     }
+
+    async fn select_all(&mut self, eid: ExpertIdRef<'_>) -> EKResult<Vec<ExpertClient>> {
+        let channels = self.inner_select_all(eid).await?;
+        channels
+            .into_iter()
+            .map(|ch| match ch {
+                ChannelMeta::Grpc(meta) => {
+                    let client = ServiceBuilder::new()
+                        .layer_fn(OTelGrpcClientMiddleware::new)
+                        .service(meta.ch.clone());
+                    Ok(ExpertClient::Grpc(client))
+                }
+                ChannelMeta::Shm(meta) => Ok(ExpertClient::Shm(meta.ch.clone())),
+                ChannelMeta::Rdma(meta) => Ok(ExpertClient::Rdma(meta.ch.clone())),
+            })
+            .collect()
+    }
+
     async fn deregister(&mut self, host_id: &str) {
         self.inner_deregister(host_id).await;
     }
@@ -173,30 +395,31 @@ impl ExpertRegistryImpl {
 
     async fn inner_select(&mut self, eid: ExpertIdRef<'_>) -> EKResult<ChannelMeta> {
         let channels = self.eid2channels.get(eid);
-        if let Some(channels) = channels {
-            if channels.is_empty() {
-                return self.create_then_select_channel(eid).await;
-            }
-            self.select_random(eid).await
-        } else {
-            self.create_then_select_channel(eid).await
-        }
-    }
-
-    async fn select_random(&mut self, eid: ExpertIdRef<'_>) -> EKResult<ChannelMeta> {
-        let channels = self.eid2channels.get(eid);
-        if let Some(channels) = channels {
-            if channels.is_empty() {
-                return self.create_then_select_channel(eid).await;
-            }
+        if let Some(channels) = channels
+            && !channels.is_empty()
+        {
             let idx = rand::random::<usize>() % channels.len();
-            Ok(channels[idx].clone())
+            return Ok(channels[idx].clone());
+        }
+        let channels = self.create_then_select_channels(eid).await?;
+        let idx = rand::random::<usize>() % channels.len();
+        Ok(channels[idx].clone())
+    }
+
+    async fn inner_select_all(&mut self, eid: ExpertIdRef<'_>) -> EKResult<Vec<ChannelMeta>> {
+        if let Some(channels) = self.eid2channels.get(eid)
+            && !channels.is_empty()
+        {
+            Ok(channels.clone())
         } else {
-            self.create_then_select_channel(eid).await
+            Ok(self.create_then_select_channels(eid).await?.clone())
         }
     }
 
-    async fn create_then_select_channel(&mut self, eid: ExpertIdRef<'_>) -> EKResult<ChannelMeta> {
+    async fn create_then_select_channels(
+        &mut self,
+        eid: ExpertIdRef<'_>,
+    ) -> EKResult<&Vec<ChannelMeta>> {
         let nodes = self.reader.node_by_expert(eid).await?;
         for node in nodes {
             let addr = node.config["addr"].as_str().unwrap().to_owned();
@@ -254,13 +477,8 @@ impl ExpertRegistryImpl {
         let res = self.eid2channels.get(eid).ok_or(EKError::NotFound(format!(
             "no channel found for expert {eid}"
         )))?;
-        if res.is_empty() {
-            return Err(EKError::NotFound(format!(
-                "no channel found for expert {eid}"
-            )));
-        }
-        let idx = rand::random::<usize>() % res.len();
-        Ok(res[idx].clone())
+
+        Ok(res)
     }
 
     /// Setup RDMA channel for a specific node and expert

--- a/ek-computation/src/controller/registry.rs
+++ b/ek-computation/src/controller/registry.rs
@@ -35,15 +35,33 @@ use serde_json;
 pub type ExpertId = String;
 pub type ExpertIdRef<'a> = &'a str;
 
-pub type LocalShmChannel = (
-    Arc<Mutex<ShmQueue<'static, ShmqWorkerReq>>>,
-    Arc<Mutex<ShmQueue<'static, ShmqWorkerResp>>>,
-);
+pub type LocalShmReqQueue = Arc<Mutex<ShmQueue<'static, ShmqWorkerReq>>>;
+pub type LocalShmRespQueue = Arc<Mutex<(ShmQueue<'static, ShmqWorkerResp>, ChannelMetrics)>>;
+pub type LocalShmChannel = (LocalShmReqQueue, LocalShmRespQueue);
 
-pub type RdmaChannel = (
-    Arc<Mutex<RdmaQueue<ShmqWorkerReq>>>,
-    Arc<Mutex<RdmaQueue<ShmqWorkerResp>>>,
-);
+pub type RdmaReqQueue = Arc<Mutex<RdmaQueue<ShmqWorkerReq>>>;
+pub type RdmaRespQueue = Arc<Mutex<(RdmaQueue<ShmqWorkerResp>, ChannelMetrics)>>;
+pub type RdmaChannel = (RdmaReqQueue, RdmaRespQueue);
+
+pub struct ChannelMetrics {
+    priority: f64,
+}
+
+impl ChannelMetrics {
+    pub fn priority(&self) -> f64 {
+        self.priority
+    }
+
+    pub fn accumulate(&mut self, delta: f64) {
+        self.priority = (self.priority * 0.8 + delta) / 2.0;
+    }
+}
+
+impl Default for ChannelMetrics {
+    fn default() -> Self {
+        Self { priority: 1.0 }
+    }
+}
 
 #[derive(Clone)]
 pub enum ExpertClient {
@@ -63,6 +81,28 @@ impl std::fmt::Debug for ExpertClient {
 }
 
 impl ExpertClient {
+    pub(crate) async fn get_priority(&self) -> f64 {
+        match self {
+            ExpertClient::Grpc(_) => 1.0, // gRPC client does not have priority tracking
+            ExpertClient::Shm((_, resp_channel)) => resp_channel.lock().await.1.priority(),
+            ExpertClient::Rdma((_, resp_channel)) => resp_channel.lock().await.1.priority(),
+        }
+    }
+
+    pub(crate) async fn update_priority(&self, delta: f64) {
+        match self {
+            ExpertClient::Grpc(_) => {
+                // gRPC client does not have priority tracking
+            }
+            ExpertClient::Shm((_, resp_channel)) => {
+                resp_channel.lock().await.1.accumulate(delta);
+            }
+            ExpertClient::Rdma((_, resp_channel)) => {
+                resp_channel.lock().await.1.accumulate(delta);
+            }
+        }
+    }
+
     pub(crate) fn forward(
         self,
         expert_id: ExpertId,
@@ -86,9 +126,10 @@ impl ExpertClient {
                     };
 
                     let _d = Self::create_metrics_defer();
+                    let now = time::Instant::now();
                     cli.forward(req)
                         .await
-                        .map(|resp| ForwardResponse::Grpc(resp.into_inner()))
+                        .map(|resp| ForwardResponse::grpc(resp.into_inner(), now.elapsed()))
                         .map_err(|e| {
                             log::error!("forward error: {e}");
                             EKError::IoError(std::io::Error::other(format!("grpc error: {e}")))
@@ -101,6 +142,7 @@ impl ExpertClient {
                 let fu = async move {
                     let req = ShmqWorkerReq::new(expert_id.as_ref(), &tensor);
                     let _d = Self::create_metrics_defer();
+                    let now = time::Instant::now();
 
                     // Send request with retry
                     if let Err(e) =
@@ -124,7 +166,7 @@ impl ExpertClient {
                     )
                     .await
                     {
-                        Ok(resp) => Ok(ForwardResponse::Shm(resp)),
+                        Ok(resp) => Ok(ForwardResponse::shm(resp, now.elapsed())),
                         Err(e) => {
                             log::error!("Failed to receive SHM response: {e:?}");
                             Err(e)
@@ -138,6 +180,7 @@ impl ExpertClient {
                 let fu = async move {
                     let req = ShmqWorkerReq::new(expert_id.as_ref(), &tensor);
                     let _d = Self::create_metrics_defer();
+                    let now = time::Instant::now();
 
                     // Send request with retry
                     if let Err(e) =
@@ -161,7 +204,7 @@ impl ExpertClient {
                     )
                     .await
                     {
-                        Ok(resp) => Ok(ForwardResponse::Rdma(resp)),
+                        Ok(resp) => Ok(ForwardResponse::rdma(resp, now.elapsed())),
                         Err(e) => {
                             log::error!("Failed to receive RDMA response: {e:?}");
                             Err(e)
@@ -188,7 +231,7 @@ impl ExpertClient {
 
     /// Handle shared memory request sending with retry logic
     async fn send_shm_request_with_retry(
-        send_channel: &Arc<Mutex<ShmQueue<'static, ShmqWorkerReq>>>,
+        send_channel: &LocalShmReqQueue,
         req: &ShmqWorkerReq,
         expert_id: &str,
     ) -> EKResult<()> {
@@ -201,7 +244,7 @@ impl ExpertClient {
 
     /// Handle RDMA request sending with retry logic
     async fn send_rdma_request_with_retry(
-        send_channel: &Arc<Mutex<RdmaQueue<ShmqWorkerReq>>>,
+        send_channel: &RdmaReqQueue,
         req: &ShmqWorkerReq,
         expert_id: &str,
     ) -> EKResult<()> {
@@ -219,7 +262,7 @@ impl ExpertClient {
 
     /// Handle shared memory response reception with ID matching
     async fn receive_shm_response(
-        recv_channel: &Arc<Mutex<ShmQueue<'static, ShmqWorkerResp>>>,
+        recv_channel: &LocalShmRespQueue,
         pending_resp: &Arc<Mutex<HashMap<usize, PendingResponse>>>,
         req_id: usize,
         expert_id: &str,
@@ -233,7 +276,7 @@ impl ExpertClient {
             }
 
             // Receive new response
-            match recv_channel.lock().await.recv() {
+            match recv_channel.lock().await.0.recv() {
                 Ok(resp) => {
                     if resp.id() != req_id {
                         log::debug!(
@@ -258,7 +301,7 @@ impl ExpertClient {
 
     /// Handle RDMA response reception with ID matching
     async fn receive_rdma_response(
-        recv_channel: &Arc<Mutex<RdmaQueue<ShmqWorkerResp>>>,
+        recv_channel: &RdmaRespQueue,
         pending_resp: &Arc<Mutex<HashMap<usize, PendingResponse>>>,
         req_id: usize,
         expert_id: &str,
@@ -272,7 +315,7 @@ impl ExpertClient {
             }
 
             // Receive new response
-            match recv_channel.lock().await.recv() {
+            match recv_channel.lock().await.0.recv() {
                 Ok(resp) => {
                     if resp.id() != req_id {
                         log::debug!(
@@ -332,8 +375,8 @@ enum ChannelMeta {
 /// RDMA connection state for a worker node
 #[derive(Clone)]
 struct RdmaNodeConnection {
-    req_queue: Arc<Mutex<RdmaQueue<ShmqWorkerReq>>>,
-    resp_queue: Arc<Mutex<RdmaQueue<ShmqWorkerResp>>>,
+    req_queue: RdmaReqQueue,
+    resp_queue: RdmaRespQueue,
     connected: bool,
 }
 
@@ -448,9 +491,9 @@ impl ExpertRegistryImpl {
                                 &format!("ek-shmq-req-{}", node.hostname),
                                 128,
                             )));
-                            let resp_queue = Arc::new(Mutex::new(ShmQueue::new(
-                                &format!("ek-shmq-resp-{}", node.hostname),
-                                128,
+                            let resp_queue = Arc::new(Mutex::new((
+                                ShmQueue::new(&format!("ek-shmq-resp-{}", node.hostname), 128),
+                                ChannelMetrics::default(),
                             )));
                             (req_queue, resp_queue)
                         });
@@ -593,7 +636,7 @@ impl ExpertRegistryImpl {
             // Create connection entry
             let connection = RdmaNodeConnection {
                 req_queue: Arc::new(Mutex::new(req_queue)),
-                resp_queue: Arc::new(Mutex::new(resp_queue)),
+                resp_queue: Arc::new(Mutex::new((resp_queue, ChannelMetrics::default()))),
                 connected: false,
             };
 
@@ -754,14 +797,15 @@ impl ExpertRegistryImpl {
             // Connect controller's response queue to worker's response queue (for receiving responses)
             {
                 let mut resp_queue = connection.resp_queue.lock().await;
-                if resp_queue.is_connected() {
+                if resp_queue.0.is_connected() {
                     log::info!(
                         "Controller response queue already connected to worker {}, skipping",
                         hostname
                     );
                 } else {
-                    if let Err(e) =
-                        resp_queue.connect(worker_resp_qp_endpoint, worker_resp_memory_region)
+                    if let Err(e) = resp_queue
+                        .0
+                        .connect(worker_resp_qp_endpoint, worker_resp_memory_region)
                     {
                         log::error!(
                             "Failed to connect controller response queue to worker {}: {e}",


### PR DESCRIPTION
Current implementation chunks the input tensor (shape=[B, N], B is batch size, N is hidden dimension) into multiple tensors (same shape), and send them to different backend workers.

TODO:
- [ ] Performance is poor now...
- [ ] Clean code