### PR TITLE
Fix: Make Rdma connection establishment stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1448,6 +1448,7 @@ dependencies = [
  "tower 0.5.2",
  "tracing",
  "tracing-opentelemetry",
+ "url",
 ]
 
 [[package]]
@@ -1639,9 +1640,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -2230,9 +2231,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -3098,9 +3099,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -5595,13 +5596,14 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,9 @@ gethostname = "1"
 half = { version = "2.6.0", features = ["rand_distr", "num-traits"] }
 http = "1.3.1"
 # This ibverbs version support one-sided RDMA
-ibverbs = { git = "https://github.com/jonhoo/rust-ibverbs", rev = "fa92aa3878151eb7ac44496fb36caa9d0197da6d", features = ["serde"] }
+ibverbs = { git = "https://github.com/jonhoo/rust-ibverbs", rev = "fa92aa3878151eb7ac44496fb36caa9d0197da6d", features = [
+    "serde",
+] }
 indicatif = "0.17.11"
 lazy_static = "1.5.0"
 libc = "0.2.172"
@@ -131,3 +133,4 @@ tracing-subscriber = { version = "0.3.19", default-features = false, features = 
     "registry",
     "local-time",
 ] }
+url = "2.5.7"

--- a/ek-computation/Cargo.toml
+++ b/ek-computation/Cargo.toml
@@ -44,6 +44,7 @@ tonic = { workspace = true }
 tower = { workspace = true }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
+url = { workspace = true }
 
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/ek-computation/examples/rdma_controller.rs
+++ b/ek-computation/examples/rdma_controller.rs
@@ -149,7 +149,7 @@ fn main() -> io::Result<()> {
     thread::sleep(Duration::from_secs(5));
 
     // Clean up
-    sender_queue.close();
+    sender_queue.disconnect();
     println!("🔄 Controller shutting down");
 
     Ok(())

--- a/ek-computation/examples/rdma_worker.rs
+++ b/ek-computation/examples/rdma_worker.rs
@@ -184,7 +184,7 @@ fn main() -> io::Result<()> {
     thread::sleep(Duration::from_secs(2));
 
     // Clean up
-    receiver_queue.close();
+    receiver_queue.disconnect();
     println!("🔄 Worker shutting down");
 
     Ok(())

--- a/ek-computation/src/controller/registry.rs
+++ b/ek-computation/src/controller/registry.rs
@@ -17,14 +17,12 @@ use tonic::transport::Channel;
 use tower::ServiceBuilder;
 
 use crate::{
-    shmq::{GeneralShmQueueBytes, ShmQueue, rdma_impl::RdmaQueue},
+    shmq::{GeneralShmQueueBytes, RdmaEndpointClient, ShmQueue, rdma_impl::RdmaQueue},
     state::{
         io::{StateReader, StateReaderImpl},
-        models::NewNode,
         writer::StateWriterImpl,
     },
 };
-use serde_json;
 
 pub type ExpertId = String;
 pub type ExpertIdRef<'a> = &'a str;
@@ -131,6 +129,7 @@ enum ChannelMeta {
 struct RdmaNodeConnection {
     req_queue: Arc<Mutex<RdmaQueue<ShmqWorkerReq>>>,
     resp_queue: Arc<Mutex<RdmaQueue<ShmqWorkerResp>>>,
+    tcp_port: Option<u16>,
     connected: bool,
 }
 
@@ -274,21 +273,23 @@ impl ExpertRegistryImpl {
             node.hostname
         );
 
-        let worker_rdma_req_endpoint = node.config.get("worker_rdma_request_endpoint");
-        let worker_rdma_resp_endpoint = node.config.get("worker_rdma_response_endpoint");
-        if worker_rdma_req_endpoint.is_none() || worker_rdma_resp_endpoint.is_none() {
-            log::warn!(
-                "Missing worker RDMA endpoints for node {} (req: {}, resp: {})",
-                node.hostname,
-                worker_rdma_req_endpoint.is_some(),
-                worker_rdma_resp_endpoint.is_some()
-            );
+        // Get worker's TCP port for RDMA endpoint exchange
+        let worker_tcp_port = node
+            .config
+            .get("rdma_tcp_port")
+            .and_then(|v| v.as_u64())
+            .map(|p| p as u16);
+
+        if worker_tcp_port.is_none() {
+            log::warn!("Missing worker RDMA TCP port for node {}", node.hostname);
             return Ok(());
         }
 
-        // Extract worker's endpoint info from database
-        let worker_req_endpoint_info = worker_rdma_req_endpoint.unwrap();
-        let worker_resp_endpoint_info = worker_rdma_resp_endpoint.unwrap();
+        let tcp_port = worker_tcp_port.unwrap();
+
+        // Extract worker IP address from addr field
+        let worker_addr = node.config["addr"].as_str().unwrap();
+        let worker_ip = self.extract_ip_from_addr(worker_addr)?;
 
         // Check if we already have a connection for this node
         let needs_new_connection = !self.all_rdma_connections.contains_key(&node.hostname);
@@ -307,99 +308,33 @@ impl ExpertRegistryImpl {
                 )))
             })?;
 
-            // Get controller endpoints for handshake
-            let controller_req_endpoint = req_queue.endpoint().map_err(|e| {
-                EKError::IoError(std::io::Error::other(format!(
-                    "Failed to get controller request endpoint: {e}"
-                )))
-            })?;
-            let controller_req_memory = req_queue.memory_region();
-            let controller_resp_endpoint = resp_queue.endpoint().map_err(|e| {
-                EKError::IoError(std::io::Error::other(format!(
-                    "Failed to get controller response endpoint: {e}"
-                )))
-            })?;
-            let controller_resp_memory = resp_queue.memory_region();
-
-            // Serialize controller endpoints as JSON strings
-            let controller_req_qp_json =
-                serde_json::to_string(&controller_req_endpoint).map_err(|e| {
-                    EKError::InvalidInput(format!(
-                        "Failed to serialize controller request QP endpoint: {e}"
-                    ))
-                })?;
-            let controller_req_memory_json = serde_json::to_string(&controller_req_memory)
-                .map_err(|e| {
-                    EKError::InvalidInput(format!(
-                        "Failed to serialize controller request memory region: {e}"
-                    ))
-                })?;
-            let controller_resp_qp_json = serde_json::to_string(&controller_resp_endpoint)
-                .map_err(|e| {
-                    EKError::InvalidInput(format!(
-                        "Failed to serialize controller response QP endpoint: {e}"
-                    ))
-                })?;
-            let controller_resp_memory_json = serde_json::to_string(&controller_resp_memory)
-                .map_err(|e| {
-                    EKError::InvalidInput(format!(
-                        "Failed to serialize controller response memory region: {e}"
-                    ))
-                })?;
-
-            let mut updated_config = node.config.clone();
-
-            // Store controller endpoints as JSON strings (consistent with worker endpoints)
-            updated_config["controller_rdma_request_endpoint"] = serde_json::json!({
-                "qp_endpoint": controller_req_qp_json,
-                "memory_region": controller_req_memory_json,
-            });
-
-            updated_config["controller_rdma_response_endpoint"] = serde_json::json!({
-                "qp_endpoint": controller_resp_qp_json,
-                "memory_region": controller_resp_memory_json,
-            });
-
-            // Update database with controller endpoint info
-            let node_update = NewNode {
-                hostname: node.hostname.clone(),
-                device: node.device.clone(),
-                config: updated_config,
-            };
-
-            // Store controller endpoint in database
-            if let Err(e) = self.writer.node_upsert(node_update).await {
-                log::error!("Failed to store controller RDMA endpoint in database: {e:?}");
-            }
+            let req_queue_arc = Arc::new(Mutex::new(req_queue));
+            let resp_queue_arc = Arc::new(Mutex::new(resp_queue));
 
             // Create connection entry
             let connection = RdmaNodeConnection {
-                req_queue: Arc::new(Mutex::new(req_queue)),
-                resp_queue: Arc::new(Mutex::new(resp_queue)),
+                req_queue: req_queue_arc.clone(),
+                resp_queue: resp_queue_arc.clone(),
+                tcp_port: Some(tcp_port),
                 connected: false,
             };
 
             self.all_rdma_connections
                 .insert(node.hostname.clone(), connection);
-        }
 
-        // Attempt to establish RDMA connection if worker endpoints are available
-        if let Err(e) = self
-            .connect_to_worker(
-                &node.hostname,
-                worker_req_endpoint_info,
-                worker_resp_endpoint_info,
-            )
-            .await
-        {
-            log::error!(
-                "Failed to establish RDMA connection to worker {}: {e:?}",
-                node.hostname
-            );
+            // Attempt to establish RDMA connection via TCP
+            if let Err(e) = self
+                .connect_to_worker_via_tcp(&node.hostname, &worker_ip, tcp_port)
+                .await
+            {
+                log::error!(
+                    "Failed to establish RDMA connection to worker {}: {e:?}",
+                    node.hostname
+                );
+            }
         }
 
         let connection = self.all_rdma_connections.get(&node.hostname).unwrap();
-
         let rdma_channel = (connection.req_queue.clone(), connection.resp_queue.clone());
 
         let meta = RdmaChannelMeta {
@@ -415,155 +350,36 @@ impl ExpertRegistryImpl {
         Ok(())
     }
 
-    /// Establish RDMA connection to a worker node
-    async fn connect_to_worker(
+    /// Establish RDMA connection to a worker node via TCP
+    async fn connect_to_worker_via_tcp(
         &mut self,
         hostname: &str,
-        worker_req_endpoint_info: &serde_json::Value,
-        worker_resp_endpoint_info: &serde_json::Value,
+        worker_ip: &str,
+        tcp_port: u16,
     ) -> EKResult<()> {
         if let Some(connection) = self.all_rdma_connections.get_mut(hostname) {
             if connection.connected {
                 return Ok(()); // Already connected
             }
-            log::debug!(
-                "Worker request endpoint info: {:?}",
-                worker_req_endpoint_info
-            );
-            log::debug!(
-                "Worker response endpoint info: {:?}",
-                worker_resp_endpoint_info
-            );
-
-            // Extract worker request endpoint JSON strings from database
-            let worker_req_qp_json = worker_req_endpoint_info
-                .get("qp_endpoint")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| {
-                    EKError::InvalidInput("Missing worker request qp_endpoint".into())
-                })?;
-            let worker_req_memory_json = worker_req_endpoint_info
-                .get("memory_region")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| {
-                    EKError::InvalidInput("Missing worker request memory_region".into())
-                })?;
-
-            // Extract worker response endpoint JSON strings from database
-            let worker_resp_qp_json = worker_resp_endpoint_info
-                .get("qp_endpoint")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| {
-                    EKError::InvalidInput("Missing worker response qp_endpoint".into())
-                })?;
-            let worker_resp_memory_json = worker_resp_endpoint_info
-                .get("memory_region")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| {
-                    EKError::InvalidInput("Missing worker response memory_region".into())
-                })?;
-
-            // Deserialize worker request endpoint information
-            let worker_req_qp_endpoint: ibverbs::QueuePairEndpoint =
-                serde_json::from_str(worker_req_qp_json).map_err(|e| {
-                    EKError::InvalidInput(format!(
-                        "Failed to deserialize worker request QP endpoint: {e}"
-                    ))
-                })?;
-            let worker_req_memory_region: ibverbs::RemoteMemoryRegion =
-                serde_json::from_str(worker_req_memory_json).map_err(|e| {
-                    EKError::InvalidInput(format!(
-                        "Failed to deserialize worker request memory region: {e}"
-                    ))
-                })?;
-
-            // Deserialize worker response endpoint information
-            let worker_resp_qp_endpoint: ibverbs::QueuePairEndpoint =
-                serde_json::from_str(worker_resp_qp_json).map_err(|e| {
-                    EKError::InvalidInput(format!(
-                        "Failed to deserialize worker response QP endpoint: {e}"
-                    ))
-                })?;
-            let worker_resp_memory_region: ibverbs::RemoteMemoryRegion =
-                serde_json::from_str(worker_resp_memory_json).map_err(|e| {
-                    EKError::InvalidInput(format!(
-                        "Failed to deserialize worker response memory region: {e}"
-                    ))
-                })?;
 
             log::info!(
-                "Establishing RDMA connection to worker {} using endpoint data",
-                hostname
-            );
-            log::debug!("Worker request QP endpoint: {:?}", worker_req_qp_endpoint);
-            log::debug!(
-                "Worker request memory region: {:?}",
-                worker_req_memory_region
-            );
-            log::debug!("Worker response QP endpoint: {:?}", worker_resp_qp_endpoint);
-            log::debug!(
-                "Worker response memory region: {:?}",
-                worker_resp_memory_region
+                "Establishing RDMA connection to worker {} (IP: {}) via TCP port {}",
+                hostname,
+                worker_ip,
+                tcp_port
             );
 
-            // Connect controller's request queue to worker's request queue (for sending requests)
-            {
-                let mut req_queue = connection.req_queue.lock().await;
-                if req_queue.is_connected() {
-                    log::info!(
-                        "Controller request queue already connected to worker {}, skipping",
-                        hostname
-                    );
-                } else {
-                    if let Err(e) =
-                        req_queue.connect(worker_req_qp_endpoint, worker_req_memory_region.clone())
-                    {
-                        log::error!(
-                            "Failed to connect controller request queue to worker {}: {e}",
-                            hostname
-                        );
-                        return Err(EKError::IoError(std::io::Error::other(format!(
-                            "Controller request queue connection failed: {e}"
-                        ))));
-                    }
-                    log::info!(
-                        "🚀Controller request queue connected to worker {} successfully",
-                        hostname
-                    );
-                }
-            }
+            // Use the TCP client to connect and exchange endpoints
+            let req_queue = connection.req_queue.clone();
+            let resp_queue = connection.resp_queue.clone();
 
-            // Connect controller's response queue to worker's response queue (for receiving responses)
-            {
-                let mut resp_queue = connection.resp_queue.lock().await;
-                if resp_queue.is_connected() {
-                    log::info!(
-                        "Controller response queue already connected to worker {}, skipping",
-                        hostname
-                    );
-                } else {
-                    if let Err(e) =
-                        resp_queue.connect(worker_resp_qp_endpoint, worker_resp_memory_region)
-                    {
-                        log::error!(
-                            "Failed to connect controller response queue to worker {}: {e}",
-                            hostname
-                        );
-                        return Err(EKError::IoError(std::io::Error::other(format!(
-                            "Controller response queue connection failed: {e}"
-                        ))));
-                    }
-                    log::info!(
-                        "🚀Controller response queue connected to worker {} successfully",
-                        hostname
-                    );
-                }
-            }
-            // Sleep for a while
-            std::thread::sleep(std::time::Duration::from_secs(2));
+            RdmaEndpointClient::connect_and_exchange(worker_ip, tcp_port, req_queue, resp_queue)
+                .await
+                .map_err(|e| EKError::IoError(e))?;
 
             // Mark connection as established
             connection.connected = true;
+
             log::info!(
                 "🚀RDMA connection to worker {} established successfully",
                 hostname
@@ -571,6 +387,26 @@ impl ExpertRegistryImpl {
         }
 
         Ok(())
+    }
+
+    /// Extract IP address from worker addr (e.g., "http://192.168.1.100:8080" -> "192.168.1.100")
+    fn extract_ip_from_addr(&self, addr: &str) -> EKResult<String> {
+        // Remove protocol prefix (http:// or https://)
+        let without_protocol = if addr.starts_with("http://") {
+            &addr[7..]
+        } else if addr.starts_with("https://") {
+            &addr[8..]
+        } else {
+            addr
+        };
+
+        // Extract host part (before the port)
+        let host = without_protocol
+            .split(':')
+            .next()
+            .ok_or_else(|| EKError::InvalidInput("Invalid worker address format".to_string()))?;
+
+        Ok(host.to_string())
     }
 
     /// Reset connection state and force reconnection on next use

--- a/ek-computation/src/controller/registry.rs
+++ b/ek-computation/src/controller/registry.rs
@@ -6,6 +6,10 @@ use std::{
     },
 };
 
+use crate::{
+    shmq::{GeneralShmQueueBytes, RdmaEndpointClient, ShmQueue, rdma_impl::RdmaQueue},
+    state::io::{StateReader, StateReaderImpl},
+};
 use ek_base::{
     error::{EKError, EKResult},
     tracing::grpc::OTelGrpcClientMiddleware,
@@ -15,11 +19,10 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tonic::transport::Channel;
 use tower::ServiceBuilder;
+use url::Url;
 
-use crate::{
-    shmq::{GeneralShmQueueBytes, RdmaEndpointClient, ShmQueue, rdma_impl::RdmaQueue},
-    state::io::{StateReader, StateReaderImpl},
-};
+const MAX_RETRIES: u32 = 3;
+const BASE_DELAY_MS: u64 = 1000;
 
 pub type ExpertId = String;
 pub type ExpertIdRef<'a> = &'a str;
@@ -316,16 +319,9 @@ impl ExpertRegistryImpl {
             self.all_rdma_connections
                 .insert(node.hostname.clone(), connection);
 
-            // Attempt to establish RDMA connection via TCP
-            if let Err(e) = self
-                .connect_to_worker_via_tcp(&node.hostname, &worker_ip, tcp_port)
-                .await
-            {
-                log::error!(
-                    "Failed to establish RDMA connection to worker {}: {e:?}",
-                    node.hostname
-                );
-            }
+            // Attempt to establish RDMA connection via TCP with retry
+            self.connect_to_worker_via_tcp_with_retry(&node.hostname, &worker_ip, tcp_port)
+                .await?;
         }
 
         let connection = self.all_rdma_connections.get(&node.hostname).unwrap();
@@ -383,22 +379,53 @@ impl ExpertRegistryImpl {
         Ok(())
     }
 
+    /// Establish RDMA connection to a worker node via TCP with retry logic
+    async fn connect_to_worker_via_tcp_with_retry(
+        &mut self,
+        hostname: &str,
+        worker_ip: &str,
+        tcp_port: u16,
+    ) -> EKResult<()> {
+        let mut last_error = None;
+
+        for attempt in 0..MAX_RETRIES {
+            match self
+                .connect_to_worker_via_tcp(hostname, worker_ip, tcp_port)
+                .await
+            {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    last_error = Some(e);
+                    if attempt < MAX_RETRIES - 1 {
+                        let delay_ms = BASE_DELAY_MS * 2_u64.pow(attempt);
+                        log::warn!(
+                            "RDMA connection attempt {} failed for worker {}, retrying in {}ms: {:?}",
+                            attempt + 1,
+                            hostname,
+                            delay_ms,
+                            last_error.as_ref().unwrap()
+                        );
+                        tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
+                    }
+                }
+            }
+        }
+
+        // Clean up failed connection entry before returning error
+        self.all_rdma_connections.remove(hostname);
+
+        Err(last_error
+            .unwrap_or_else(|| EKError::IoError(std::io::Error::other("Unknown connection error"))))
+    }
+
     /// Extract IP address from worker addr (e.g., "http://192.168.1.100:8080" -> "192.168.1.100")
     fn extract_ip_from_addr(&self, addr: &str) -> EKResult<String> {
-        // Remove protocol prefix (http:// or https://)
-        let without_protocol = if addr.starts_with("http://") {
-            &addr[7..]
-        } else if addr.starts_with("https://") {
-            &addr[8..]
-        } else {
-            addr
-        };
+        let url = Url::parse(addr)
+            .map_err(|e| EKError::InvalidInput(format!("Invalid URL format: {e}")))?;
 
-        // Extract host part (before the port)
-        let host = without_protocol
-            .split(':')
-            .next()
-            .ok_or_else(|| EKError::InvalidInput("Invalid worker address format".to_string()))?;
+        let host = url
+            .host_str()
+            .ok_or_else(|| EKError::InvalidInput("No host found in URL".to_string()))?;
 
         Ok(host.to_string())
     }

--- a/ek-computation/src/controller/registry.rs
+++ b/ek-computation/src/controller/registry.rs
@@ -18,10 +18,7 @@ use tower::ServiceBuilder;
 
 use crate::{
     shmq::{GeneralShmQueueBytes, RdmaEndpointClient, ShmQueue, rdma_impl::RdmaQueue},
-    state::{
-        io::{StateReader, StateReaderImpl},
-        writer::StateWriterImpl,
-    },
+    state::io::{StateReader, StateReaderImpl},
 };
 
 pub type ExpertId = String;
@@ -129,7 +126,6 @@ enum ChannelMeta {
 struct RdmaNodeConnection {
     req_queue: Arc<Mutex<RdmaQueue<ShmqWorkerReq>>>,
     resp_queue: Arc<Mutex<RdmaQueue<ShmqWorkerResp>>>,
-    tcp_port: Option<u16>,
     connected: bool,
 }
 
@@ -138,7 +134,6 @@ pub struct ExpertRegistryImpl {
     all_shm_channels: HashMap<String, LocalShmChannel>,
     all_rdma_connections: HashMap<String, RdmaNodeConnection>,
     reader: Box<dyn StateReader + Send + Sync>,
-    writer: StateWriterImpl,
 }
 
 #[async_trait::async_trait]
@@ -315,7 +310,6 @@ impl ExpertRegistryImpl {
             let connection = RdmaNodeConnection {
                 req_queue: req_queue_arc.clone(),
                 resp_queue: resp_queue_arc.clone(),
-                tcp_port: Some(tcp_port),
                 connected: false,
             };
 
@@ -455,7 +449,6 @@ impl ExpertRegistryImpl {
             all_shm_channels: HashMap::new(),
             all_rdma_connections: HashMap::new(),
             reader: Box::new(StateReaderImpl::new()),
-            writer: StateWriterImpl::new(),
         }
     }
 }

--- a/ek-computation/src/controller/service/state.rs
+++ b/ek-computation/src/controller/service/state.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     proto::ek::{
         object::v1::ExpertSlice,
-        worker::v1::{self, ExchangeResp, RdmaEndpoint, RdmaEndpointPair},
+        worker::v1::{self, ExchangeResp},
     },
     state::{
         io::{StateReader, StateReaderImpl},
@@ -55,20 +55,9 @@ impl StateServerImpl {
                     config["addr"] = serde_json::json!(msg.addr.clone());
                     config["channel"] = serde_json::json!(msg.channel.clone());
 
-                    if let Some(rdma_endpoints) = &msg.rdma_endpoints {
-                        if let Some(worker_req_endpoint) = &rdma_endpoints.request_endpoint {
-                            config["worker_rdma_request_endpoint"] = serde_json::json!({
-                                "qp_endpoint": worker_req_endpoint.qp_endpoint,
-                                "memory_region": worker_req_endpoint.memory_region,
-                            });
-                        }
-
-                        if let Some(worker_resp_endpoint) = &rdma_endpoints.response_endpoint {
-                            config["worker_rdma_response_endpoint"] = serde_json::json!({
-                                "qp_endpoint": worker_resp_endpoint.qp_endpoint,
-                                "memory_region": worker_resp_endpoint.memory_region,
-                            });
-                        }
+                    // Store RDMA TCP port if provided
+                    if msg.rdma_tcp_port > 0 {
+                        config["rdma_tcp_port"] = serde_json::json!(msg.rdma_tcp_port);
                     }
 
                     let err = w
@@ -130,17 +119,9 @@ impl StateService for StateServerImpl {
             .ok_or(Status::invalid_argument("no message"))?;
         let worker_id = first_message.id.clone();
 
-        // If channel is rdma, clear deprecated RDMA endpoints from database
-        if first_message.channel == "rdma" {
-            let w = StateWriterImpl {};
-            if let Err(e) = w.clear_node_config_by_hostname(&worker_id).await {
-                log::error!(
-                    "Failed to clear deprecated RDMA endpoints for worker {}: {e}",
-                    worker_id
-                );
-            } else {
-                log::info!("Cleared deprecated RDMA endpoints for worker {}", worker_id);
-            }
+        // Log RDMA TCP port if provided
+        if first_message.channel == "rdma" && first_message.rdma_tcp_port > 0 {
+            log::info!("Worker {} using RDMA with TCP port {}", worker_id, first_message.rdma_tcp_port);
         }
 
         // Handle incoming worker requests: Ping
@@ -154,62 +135,17 @@ impl StateService for StateServerImpl {
         let mut rx = dispather_guard.subscribe(&first_message.id).await;
 
         // Handle outgoing messages to the worker: New Experts
-        let worker_id_for_spawn = worker_id.clone();
+        let _worker_id_for_spawn = worker_id.clone();
         tokio::spawn(async move {
-            let reader = StateReaderImpl::new();
+            let _reader = StateReaderImpl::new();
 
             while let Some(t) = rx.recv().await {
-                // Check if the worker is using RDMA backend and fetch controller endpoints
-                let rdma_endpoints = if let Ok(Some(worker_node)) =
-                    reader.node_by_hostname(&worker_id_for_spawn).await
-                {
-                    if worker_node.config.get("channel").and_then(|v| v.as_str()) == Some("rdma") {
-                        // Extract controller endpoints from worker's database record
-                        let req_endpoint = worker_node
-                            .config
-                            .get("controller_rdma_request_endpoint")
-                            .and_then(|data| {
-                                Some(RdmaEndpoint {
-                                    qp_endpoint: data.get("qp_endpoint")?.as_str()?.to_string(),
-                                    memory_region: data.get("memory_region")?.as_str()?.to_string(),
-                                })
-                            });
-
-                        let resp_endpoint = worker_node
-                            .config
-                            .get("controller_rdma_response_endpoint")
-                            .and_then(|data| {
-                                Some(RdmaEndpoint {
-                                    qp_endpoint: data.get("qp_endpoint")?.as_str()?.to_string(),
-                                    memory_region: data.get("memory_region")?.as_str()?.to_string(),
-                                })
-                            });
-
-                        if req_endpoint.is_some() || resp_endpoint.is_some() {
-                            Some(RdmaEndpointPair {
-                                request_endpoint: req_endpoint,
-                                response_endpoint: resp_endpoint,
-                            })
-                        } else {
-                            log::debug!(
-                                "No controller RDMA endpoints found for worker {}",
-                                worker_id_for_spawn
-                            );
-                            None
-                        }
-                    } else {
-                        None
-                    }
-                } else {
-                    log::warn!("Worker node {} not found in database", worker_id_for_spawn);
-                    None
-                };
-
+                // Note: RDMA connection is now handled via direct TCP connection
+                // No complex endpoint exchange logic needed in the response stream
                 let resp = ExchangeResp {
                     state: Some(v1::exchange_resp::ExpertWithState {
                         target: Some(ExpertSlice::from(t)),
                     }),
-                    rdma_endpoints: rdma_endpoints.clone(),
                 };
                 if let Err(e) = stream_tx.send(Ok(resp)).await {
                     log::error!("stream error: {e}")

--- a/ek-computation/src/controller/service/state.rs
+++ b/ek-computation/src/controller/service/state.rs
@@ -139,13 +139,8 @@ impl StateService for StateServerImpl {
         let mut rx = dispather_guard.subscribe(&first_message.id).await;
 
         // Handle outgoing messages to the worker: New Experts
-        let _worker_id_for_spawn = worker_id.clone();
         tokio::spawn(async move {
-            let _reader = StateReaderImpl::new();
-
             while let Some(t) = rx.recv().await {
-                // Note: RDMA connection is now handled via direct TCP connection
-                // No complex endpoint exchange logic needed in the response stream
                 let resp = ExchangeResp {
                     state: Some(v1::exchange_resp::ExpertWithState {
                         target: Some(ExpertSlice::from(t)),

--- a/ek-computation/src/controller/service/state.rs
+++ b/ek-computation/src/controller/service/state.rs
@@ -121,7 +121,11 @@ impl StateService for StateServerImpl {
 
         // Log RDMA TCP port if provided
         if first_message.channel == "rdma" && first_message.rdma_tcp_port > 0 {
-            log::info!("Worker {} using RDMA with TCP port {}", worker_id, first_message.rdma_tcp_port);
+            log::info!(
+                "Worker {} using RDMA with TCP port {}",
+                worker_id,
+                first_message.rdma_tcp_port
+            );
         }
 
         // Handle incoming worker requests: Ping

--- a/ek-computation/src/shmq/mod.rs
+++ b/ek-computation/src/shmq/mod.rs
@@ -1,7 +1,9 @@
 pub mod rdma_impl;
+pub mod rdma_tcp_exchange;
 pub mod shared_mem;
 
 pub use rdma_impl::{RdmaQueue, RdmaQueueError};
+pub use rdma_tcp_exchange::{RdmaEndpointServer, RdmaEndpointClient, RdmaConnectionInfo, RdmaConnectionPair};
 pub use shared_mem::ShmQueue;
 
 /// Trait for types that can be sent over RDMA queue

--- a/ek-computation/src/shmq/mod.rs
+++ b/ek-computation/src/shmq/mod.rs
@@ -3,7 +3,9 @@ pub mod rdma_tcp_exchange;
 pub mod shared_mem;
 
 pub use rdma_impl::{RdmaQueue, RdmaQueueError};
-pub use rdma_tcp_exchange::{RdmaEndpointServer, RdmaEndpointClient, RdmaConnectionInfo, RdmaConnectionPair};
+pub use rdma_tcp_exchange::{
+    RdmaConnectionInfo, RdmaConnectionPair, RdmaEndpointClient, RdmaEndpointServer,
+};
 pub use shared_mem::ShmQueue;
 
 /// Trait for types that can be sent over RDMA queue

--- a/ek-computation/src/shmq/rdma_impl.rs
+++ b/ek-computation/src/shmq/rdma_impl.rs
@@ -2,8 +2,8 @@ use std::io;
 
 // Import from the provided ibverbs library
 use ibverbs::{
-    CompletionQueue, Context, MemoryRegion, ProtectionDomain, QueuePair, QueuePairBuilder,
-    QueuePairEndpoint, RemoteMemoryRegion, devices, ibv_qp_type,
+    CompletionQueue, Context, MemoryRegion, PreparedQueuePair, ProtectionDomain, QueuePair,
+    QueuePairBuilder, QueuePairEndpoint, RemoteMemoryRegion, devices, ibv_qp_type,
 };
 
 use crate::shmq::GeneralShmQueueBytes;
@@ -56,7 +56,7 @@ pub struct RdmaQueue<T> {
     _recv_cq: CompletionQueue,
     _qp_builder: QueuePairBuilder,
     _endpoint: QueuePairEndpoint,
-    prepared_qp: Option<ibverbs::PreparedQueuePair>,
+    prepared_qp: Option<PreparedQueuePair>,
     qp: Option<QueuePair>,
 
     // Local memory region containing queue metadata and data
@@ -71,9 +71,6 @@ pub struct RdmaQueue<T> {
 
     // Work request ID counter
     wr_id_counter: u64,
-
-    // Connection Status
-    _is_connected: bool,
 
     _phantom: std::marker::PhantomData<T>,
 }
@@ -96,7 +93,7 @@ fn offset_of_tail() -> usize {
 impl<T: GeneralShmQueueBytes> RdmaQueue<T> {
     /// Check if the queue is connected to a remote peer
     pub fn is_connected(&self) -> bool {
-        self._is_connected
+        self.qp.is_some()
     }
 
     pub fn new(device_index: Option<usize>, capacity: usize, is_sender: bool) -> io::Result<Self> {
@@ -171,7 +168,6 @@ impl<T: GeneralShmQueueBytes> RdmaQueue<T> {
             capacity,
             is_sender,
             wr_id_counter: 1,
-            _is_connected: false,
             _phantom: std::marker::PhantomData,
         })
     }
@@ -197,7 +193,9 @@ impl<T: GeneralShmQueueBytes> RdmaQueue<T> {
 
         // Complete the QP handshake using the same prepared_qp from new()
         if !self.is_connected() {
-            let prepared_qp = self.prepared_qp.take()
+            let prepared_qp = self
+                .prepared_qp
+                .take()
                 .ok_or_else(|| io::Error::other("No prepared QP available"))?;
 
             let result = prepared_qp.handshake(remote_endpoint);
@@ -205,7 +203,6 @@ impl<T: GeneralShmQueueBytes> RdmaQueue<T> {
 
             // Mark as connected
             self.qp = Some(qp);
-            self._is_connected = true;
             log::info!("🚀Connected to remote peer: {:?}", remote_endpoint);
             Ok(())
         } else {
@@ -457,12 +454,22 @@ impl<T: GeneralShmQueueBytes> RdmaQueue<T> {
         self.recv()
     }
 
-    pub fn close(&mut self) {
-        // Clean up RDMA resources in reverse order of creation
-        // This is critical to avoid "Device or resource busy" errors
-
+    /// Clean current RDMA connections and resources, and prepare for new connection
+    pub fn disconnect(&mut self) {
+        // Drop current qp
         if let Some(qp) = self.qp.take() {
             drop(qp);
+        }
+
+        // Prepare new qp
+        if self.prepared_qp.is_none() {
+            let new_prepared_qp = self
+                ._qp_builder
+                .build()
+                .expect("Failed to build new prepared QP");
+            self.prepared_qp = Some(new_prepared_qp);
+            // Update endpoint info
+            self._endpoint = self.prepared_qp.as_ref().unwrap().endpoint().unwrap();
         }
     }
 }

--- a/ek-computation/src/shmq/rdma_impl.rs
+++ b/ek-computation/src/shmq/rdma_impl.rs
@@ -52,10 +52,10 @@ pub struct RdmaQueue<T> {
     // RDMA resources
     _context: Context,
     _pd: ProtectionDomain,
-    _send_cq: CompletionQueue,
     _recv_cq: CompletionQueue,
-    _qp_builder: QueuePairBuilder,
-    _endpoint: QueuePairEndpoint,
+    send_cq: CompletionQueue,
+    qp_builder: QueuePairBuilder,
+    endpoint: QueuePairEndpoint,
     prepared_qp: Option<PreparedQueuePair>,
     qp: Option<QueuePair>,
 
@@ -157,10 +157,10 @@ impl<T: GeneralShmQueueBytes> RdmaQueue<T> {
         Ok(Self {
             _context: context,
             _pd: pd,
-            _send_cq: send_cq,
             _recv_cq: recv_cq,
-            _qp_builder: qp_builder,
-            _endpoint: endpoint,
+            send_cq,
+            qp_builder,
+            endpoint,
             prepared_qp: Some(prepared_qp),
             qp: None,
             memory_region,
@@ -174,7 +174,7 @@ impl<T: GeneralShmQueueBytes> RdmaQueue<T> {
 
     /// Get the local endpoint information for connection establishment
     pub fn endpoint(&self) -> io::Result<QueuePairEndpoint> {
-        Ok(self._endpoint.clone())
+        Ok(self.endpoint.clone())
     }
 
     /// Get the local memory region information for sharing with remote peer
@@ -413,7 +413,7 @@ impl<T: GeneralShmQueueBytes> RdmaQueue<T> {
 
         loop {
             // First try non-blocking poll
-            match self._send_cq.wait(&mut completions, None) {
+            match self.send_cq.wait(&mut completions, None) {
                 Ok(completed) => {
                     if !completed.is_empty() {
                         for completion in completed {
@@ -464,12 +464,12 @@ impl<T: GeneralShmQueueBytes> RdmaQueue<T> {
         // Prepare new qp
         if self.prepared_qp.is_none() {
             let new_prepared_qp = self
-                ._qp_builder
+                .qp_builder
                 .build()
                 .unwrap_or_else(|e| panic!("Failed to build new prepared QP: {}", e));
             self.prepared_qp = Some(new_prepared_qp);
             // Update endpoint info
-            self._endpoint = self.prepared_qp.as_ref().unwrap().endpoint().unwrap();
+            self.endpoint = self.prepared_qp.as_ref().unwrap().endpoint().unwrap();
         }
     }
 }

--- a/ek-computation/src/shmq/rdma_impl.rs
+++ b/ek-computation/src/shmq/rdma_impl.rs
@@ -466,7 +466,7 @@ impl<T: GeneralShmQueueBytes> RdmaQueue<T> {
             let new_prepared_qp = self
                 ._qp_builder
                 .build()
-                .expect("Failed to build new prepared QP");
+                .unwrap_or_else(|e| panic!("Failed to build new prepared QP: {}", e));
             self.prepared_qp = Some(new_prepared_qp);
             // Update endpoint info
             self._endpoint = self.prepared_qp.as_ref().unwrap().endpoint().unwrap();

--- a/ek-computation/src/shmq/rdma_impl.rs
+++ b/ek-computation/src/shmq/rdma_impl.rs
@@ -56,6 +56,7 @@ pub struct RdmaQueue<T> {
     _recv_cq: CompletionQueue,
     _qp_builder: QueuePairBuilder,
     _endpoint: QueuePairEndpoint,
+    prepared_qp: Option<ibverbs::PreparedQueuePair>,
     qp: Option<QueuePair>,
 
     // Local memory region containing queue metadata and data
@@ -163,6 +164,7 @@ impl<T: GeneralShmQueueBytes> RdmaQueue<T> {
             _recv_cq: recv_cq,
             _qp_builder: qp_builder,
             _endpoint: endpoint,
+            prepared_qp: Some(prepared_qp),
             qp: None,
             memory_region,
             remote_region: None,
@@ -193,9 +195,10 @@ impl<T: GeneralShmQueueBytes> RdmaQueue<T> {
         // Store remote memory region
         self.remote_region = Some(remote_region);
 
-        // Complete the QP handshake
+        // Complete the QP handshake using the same prepared_qp from new()
         if !self.is_connected() {
-            let prepared_qp = self._qp_builder.build()?;
+            let prepared_qp = self.prepared_qp.take()
+                .ok_or_else(|| io::Error::other("No prepared QP available"))?;
 
             let result = prepared_qp.handshake(remote_endpoint);
             let qp = result.map_err(|e| io::Error::other(format!("QP handshake failed: {}", e)))?;

--- a/ek-computation/src/shmq/rdma_impl.rs
+++ b/ek-computation/src/shmq/rdma_impl.rs
@@ -2,7 +2,7 @@ use std::io;
 
 // Import from the provided ibverbs library
 use ibverbs::{
-    CompletionQueue, Context, MemoryRegion, PreparedQueuePair, ProtectionDomain, QueuePair,
+    CompletionQueue, Context, MemoryRegion, ProtectionDomain, QueuePair, QueuePairBuilder,
     QueuePairEndpoint, RemoteMemoryRegion, devices, ibv_qp_type,
 };
 
@@ -54,8 +54,9 @@ pub struct RdmaQueue<T> {
     _pd: ProtectionDomain,
     _send_cq: CompletionQueue,
     _recv_cq: CompletionQueue,
+    _qp_builder: QueuePairBuilder,
+    _endpoint: QueuePairEndpoint,
     qp: Option<QueuePair>,
-    prepared_qp: Option<PreparedQueuePair>,
 
     // Local memory region containing queue metadata and data
     memory_region: MemoryRegion<Vec<u8>>,
@@ -69,6 +70,9 @@ pub struct RdmaQueue<T> {
 
     // Work request ID counter
     wr_id_counter: u64,
+
+    // Connection Status
+    _is_connected: bool,
 
     _phantom: std::marker::PhantomData<T>,
 }
@@ -91,7 +95,7 @@ fn offset_of_tail() -> usize {
 impl<T: GeneralShmQueueBytes> RdmaQueue<T> {
     /// Check if the queue is connected to a remote peer
     pub fn is_connected(&self) -> bool {
-        self.remote_region.is_some() && self.qp.is_some()
+        self._is_connected
     }
 
     pub fn new(device_index: Option<usize>, capacity: usize, is_sender: bool) -> io::Result<Self> {
@@ -150,29 +154,29 @@ impl<T: GeneralShmQueueBytes> RdmaQueue<T> {
             .allow_remote_rw();
 
         let prepared_qp = qp_builder.build()?;
+        let endpoint = prepared_qp.endpoint()?;
 
         Ok(Self {
             _context: context,
             _pd: pd,
             _send_cq: send_cq,
             _recv_cq: recv_cq,
+            _qp_builder: qp_builder,
+            _endpoint: endpoint,
             qp: None,
-            prepared_qp: Some(prepared_qp),
             memory_region,
             remote_region: None,
             capacity,
             is_sender,
             wr_id_counter: 1,
+            _is_connected: false,
             _phantom: std::marker::PhantomData,
         })
     }
 
     /// Get the local endpoint information for connection establishment
     pub fn endpoint(&self) -> io::Result<QueuePairEndpoint> {
-        match &self.prepared_qp {
-            Some(pqp) => pqp.endpoint(),
-            None => Err(io::Error::other("Queue pair already connected")),
-        }
+        Ok(self._endpoint.clone())
     }
 
     /// Get the local memory region information for sharing with remote peer
@@ -190,10 +194,16 @@ impl<T: GeneralShmQueueBytes> RdmaQueue<T> {
         self.remote_region = Some(remote_region);
 
         // Complete the QP handshake
-        if let Some(prepared_qp) = self.prepared_qp.take() {
-            let qp = prepared_qp.handshake(remote_endpoint).unwrap();
-            log::info!("🚀Connected to remote peer: {:?}", remote_endpoint);
+        if !self.is_connected() {
+            let prepared_qp = self._qp_builder.build()?;
+
+            let result = prepared_qp.handshake(remote_endpoint);
+            let qp = result.map_err(|e| io::Error::other(format!("QP handshake failed: {}", e)))?;
+
+            // Mark as connected
             self.qp = Some(qp);
+            self._is_connected = true;
+            log::info!("🚀Connected to remote peer: {:?}", remote_endpoint);
             Ok(())
         } else {
             Err(io::Error::other(
@@ -204,7 +214,7 @@ impl<T: GeneralShmQueueBytes> RdmaQueue<T> {
 
     /// Send an item to the queue (sender side) - Push-based architecture
     pub fn send(&mut self, item: &T) -> Result<(), RdmaQueueError> {
-        if !self.is_sender {
+        if !self.is_sender || !self.is_connected() {
             return Err(RdmaQueueError::IoError);
         }
         let start_time = std::time::Instant::now();
@@ -245,7 +255,7 @@ impl<T: GeneralShmQueueBytes> RdmaQueue<T> {
 
     /// Receive an item from the queue (receiver side) - Poll local memory
     pub fn recv(&mut self) -> Result<T, RdmaQueueError> {
-        if self.is_sender {
+        if self.is_sender || !self.is_connected() {
             return Err(RdmaQueueError::IoError);
         }
 

--- a/ek-computation/src/shmq/rdma_tcp_exchange.rs
+++ b/ek-computation/src/shmq/rdma_tcp_exchange.rs
@@ -1,7 +1,6 @@
 use std::io::{self, BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 use serde::{Serialize, Deserialize};
 use ibverbs::{QueuePairEndpoint, RemoteMemoryRegion};
 
@@ -57,25 +56,37 @@ impl RdmaEndpointServer {
         let listener = TcpListener::bind(format!("0.0.0.0:{}", self.tcp_port))?;
         log::info!("🌐 RDMA endpoint exchange server listening on port {}", self.tcp_port);
 
-        loop {
-            match listener.accept() {
-                Ok((stream, addr)) => {
-                    log::info!("📡 Controller connected from: {}", addr);
-                    
-                    let req_queue = self.req_queue.clone();
-                    let resp_queue = self.resp_queue.clone();
-                    
-                    // Handle connection in background
-                    tokio::task::spawn_blocking(move || {
-                        if let Err(e) = Self::handle_connection(stream, req_queue, resp_queue) {
-                            log::error!("Failed to handle RDMA endpoint exchange: {}", e);
-                        }
-                    });
+        // Accept only one connection for endpoint exchange, then shut down
+        match listener.accept() {
+            Ok((stream, addr)) => {
+                log::info!("📡 Controller connected from: {}", addr);
+                
+                let req_queue = self.req_queue.clone();
+                let resp_queue = self.resp_queue.clone();
+                
+                // Handle connection and wait for completion
+                let result = tokio::task::spawn_blocking(move || {
+                    Self::handle_connection(stream, req_queue, resp_queue)
+                }).await;
+                
+                match result {
+                    Ok(Ok(())) => {
+                        log::info!("🎯 RDMA endpoint exchange completed successfully, shutting down TCP server");
+                        Ok(())
+                    }
+                    Ok(Err(e)) => {
+                        log::error!("Failed to handle RDMA endpoint exchange: {}", e);
+                        Err(e)
+                    }
+                    Err(e) => {
+                        log::error!("RDMA endpoint exchange task panicked: {}", e);
+                        Err(io::Error::other("Endpoint exchange task failed"))
+                    }
                 }
-                Err(e) => {
-                    log::error!("Failed to accept TCP connection: {}", e);
-                    tokio::time::sleep(Duration::from_secs(1)).await;
-                }
+            }
+            Err(e) => {
+                log::error!("Failed to accept TCP connection: {}", e);
+                Err(e)
             }
         }
     }
@@ -196,7 +207,7 @@ impl RdmaEndpointClient {
         let worker_addr = format!("{}:{}", worker_host, worker_tcp_port);
         log::info!("🔗 Connecting to worker at {} for RDMA endpoint exchange", worker_addr);
 
-        let mut stream = TcpStream::connect(&worker_addr)?;
+        let stream = TcpStream::connect(&worker_addr)?;
         log::info!("✅ Connected to worker TCP server");
 
         // Get controller's RDMA endpoints

--- a/ek-computation/src/shmq/rdma_tcp_exchange.rs
+++ b/ek-computation/src/shmq/rdma_tcp_exchange.rs
@@ -1,11 +1,11 @@
+use ibverbs::{QueuePairEndpoint, RemoteMemoryRegion};
+use serde::{Deserialize, Serialize};
 use std::io::{self, BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
 use std::sync::{Arc, Mutex};
-use serde::{Serialize, Deserialize};
-use ibverbs::{QueuePairEndpoint, RemoteMemoryRegion};
 
-use crate::controller::registry::{ShmqWorkerReq, ShmqWorkerResp};
 use super::rdma_impl::RdmaQueue;
+use crate::controller::registry::{ShmqWorkerReq, ShmqWorkerResp};
 
 /// Connection information exchanged over TCP
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -26,6 +26,7 @@ pub struct RdmaEndpointServer {
     pub tcp_port: u16,
     req_queue: Arc<Mutex<RdmaQueue<ShmqWorkerReq>>>,
     resp_queue: Arc<Mutex<RdmaQueue<ShmqWorkerResp>>>,
+    poison: Arc<Mutex<bool>>,
 }
 
 impl RdmaEndpointServer {
@@ -33,16 +34,18 @@ impl RdmaEndpointServer {
     pub fn new(
         req_queue: Arc<Mutex<RdmaQueue<ShmqWorkerReq>>>,
         resp_queue: Arc<Mutex<RdmaQueue<ShmqWorkerResp>>>,
+        poison: Arc<Mutex<bool>>,
     ) -> io::Result<Self> {
         // Bind to any available port
         let listener = TcpListener::bind("0.0.0.0:0")?;
         let tcp_port = listener.local_addr()?.port();
         drop(listener); // Release the port for actual use
-        
+
         Ok(Self {
             tcp_port,
             req_queue,
             resp_queue,
+            poison,
         })
     }
 
@@ -52,43 +55,64 @@ impl RdmaEndpointServer {
     }
 
     /// Start TCP server to handle RDMA endpoint exchange
-    pub async fn start(&self) -> io::Result<()> {
+    pub fn start(&self) -> io::Result<()> {
         let listener = TcpListener::bind(format!("0.0.0.0:{}", self.tcp_port))?;
-        log::info!("🌐 RDMA endpoint exchange server listening on port {}", self.tcp_port);
+        listener.set_nonblocking(true)?;
+        log::info!(
+            "🌐 RDMA endpoint exchange server listening on port {}",
+            self.tcp_port
+        );
 
-        // Accept only one connection for endpoint exchange, then shut down
-        match listener.accept() {
-            Ok((stream, addr)) => {
-                log::info!("📡 Controller connected from: {}", addr);
-                
-                let req_queue = self.req_queue.clone();
-                let resp_queue = self.resp_queue.clone();
-                
-                // Handle connection and wait for completion
-                let result = tokio::task::spawn_blocking(move || {
-                    Self::handle_connection(stream, req_queue, resp_queue)
-                }).await;
-                
-                match result {
-                    Ok(Ok(())) => {
-                        log::info!("🎯 RDMA endpoint exchange completed successfully, shutting down TCP server");
-                        Ok(())
-                    }
-                    Ok(Err(e)) => {
-                        log::error!("Failed to handle RDMA endpoint exchange: {}", e);
-                        Err(e)
-                    }
-                    Err(e) => {
-                        log::error!("RDMA endpoint exchange task panicked: {}", e);
-                        Err(io::Error::other("Endpoint exchange task failed"))
+        // Run in loop to accept multiple connections until poison flag is set
+        loop {
+            // Check poison flag for graceful shutdown
+            if *self.poison.lock().unwrap() {
+                log::info!("RDMA endpoint server received shutdown signal");
+                break;
+            }
+
+            // Try to accept connection (non-blocking)
+            match listener.accept() {
+                Ok((stream, addr)) => {
+                    log::info!("📡 Controller connected from: {}", addr);
+
+                    let req_queue = self.req_queue.clone();
+                    let resp_queue = self.resp_queue.clone();
+
+                    // Handle connection in a separate thread
+                    let handle = std::thread::spawn(move || {
+                        Self::handle_connection(stream, req_queue, resp_queue)
+                    });
+                    
+                    // Wait for completion
+                    let result = handle.join();
+
+                    match result {
+                        Ok(Ok(())) => {
+                            log::info!("🎯 RDMA endpoint exchange completed successfully");
+                        }
+                        Ok(Err(e)) => {
+                            log::error!("Failed to handle RDMA endpoint exchange: {}", e);
+                        }
+                        Err(e) => {
+                            log::error!("RDMA endpoint exchange task panicked: {:?}", e);
+                        }
                     }
                 }
-            }
-            Err(e) => {
-                log::error!("Failed to accept TCP connection: {}", e);
-                Err(e)
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                    // No connection available, sleep briefly and continue
+                    std::thread::sleep(std::time::Duration::from_secs(1));
+                }
+                Err(e) => {
+                    log::error!("Failed to accept TCP connection: {}", e);
+                    // Don't break on connection errors, just log and continue
+                    std::thread::sleep(std::time::Duration::from_secs(1));
+                }
             }
         }
+
+        log::info!("RDMA endpoint exchange server shutting down gracefully");
+        Ok(())
     }
 
     /// Handle single TCP connection for endpoint exchange
@@ -103,7 +127,7 @@ impl RdmaEndpointServer {
         let worker_connection_pair = {
             let req_guard = req_queue.lock().unwrap();
             let resp_guard = resp_queue.lock().unwrap();
-            
+
             let req_endpoint = req_guard.endpoint()?;
             let req_memory = req_guard.memory_region();
             let resp_endpoint = resp_guard.endpoint()?;
@@ -111,16 +135,20 @@ impl RdmaEndpointServer {
 
             RdmaConnectionPair {
                 request_endpoint: RdmaConnectionInfo {
-                    qp_endpoint: serde_json::to_string(&req_endpoint)
-                        .map_err(|e| io::Error::other(format!("Failed to serialize req endpoint: {}", e)))?,
-                    memory_region: serde_json::to_string(&req_memory)
-                        .map_err(|e| io::Error::other(format!("Failed to serialize req memory: {}", e)))?,
+                    qp_endpoint: serde_json::to_string(&req_endpoint).map_err(|e| {
+                        io::Error::other(format!("Failed to serialize req endpoint: {}", e))
+                    })?,
+                    memory_region: serde_json::to_string(&req_memory).map_err(|e| {
+                        io::Error::other(format!("Failed to serialize req memory: {}", e))
+                    })?,
                 },
                 response_endpoint: RdmaConnectionInfo {
-                    qp_endpoint: serde_json::to_string(&resp_endpoint)
-                        .map_err(|e| io::Error::other(format!("Failed to serialize resp endpoint: {}", e)))?,
-                    memory_region: serde_json::to_string(&resp_memory)
-                        .map_err(|e| io::Error::other(format!("Failed to serialize resp memory: {}", e)))?,
+                    qp_endpoint: serde_json::to_string(&resp_endpoint).map_err(|e| {
+                        io::Error::other(format!("Failed to serialize resp endpoint: {}", e))
+                    })?,
+                    memory_region: serde_json::to_string(&resp_memory).map_err(|e| {
+                        io::Error::other(format!("Failed to serialize resp memory: {}", e))
+                    })?,
                 },
             }
         };
@@ -136,19 +164,32 @@ impl RdmaEndpointServer {
         let mut reader = BufReader::new(&stream);
         let mut controller_info_line = String::new();
         reader.read_line(&mut controller_info_line)?;
-        let controller_connection_pair: RdmaConnectionPair = serde_json::from_str(controller_info_line.trim())
-            .map_err(|e| io::Error::other(format!("Failed to parse controller info: {}", e)))?;
+        let controller_connection_pair: RdmaConnectionPair =
+            serde_json::from_str(controller_info_line.trim())
+                .map_err(|e| io::Error::other(format!("Failed to parse controller info: {}", e)))?;
         log::info!("📥 Received controller RDMA endpoints");
 
         // Parse controller endpoints
-        let controller_req_endpoint: QueuePairEndpoint = serde_json::from_str(&controller_connection_pair.request_endpoint.qp_endpoint)
-            .map_err(|e| io::Error::other(format!("Failed to parse controller req endpoint: {}", e)))?;
-        let controller_req_memory: RemoteMemoryRegion = serde_json::from_str(&controller_connection_pair.request_endpoint.memory_region)
-            .map_err(|e| io::Error::other(format!("Failed to parse controller req memory: {}", e)))?;
-        let controller_resp_endpoint: QueuePairEndpoint = serde_json::from_str(&controller_connection_pair.response_endpoint.qp_endpoint)
-            .map_err(|e| io::Error::other(format!("Failed to parse controller resp endpoint: {}", e)))?;
-        let controller_resp_memory: RemoteMemoryRegion = serde_json::from_str(&controller_connection_pair.response_endpoint.memory_region)
-            .map_err(|e| io::Error::other(format!("Failed to parse controller resp memory: {}", e)))?;
+        let controller_req_endpoint: QueuePairEndpoint =
+            serde_json::from_str(&controller_connection_pair.request_endpoint.qp_endpoint)
+                .map_err(|e| {
+                    io::Error::other(format!("Failed to parse controller req endpoint: {}", e))
+                })?;
+        let controller_req_memory: RemoteMemoryRegion =
+            serde_json::from_str(&controller_connection_pair.request_endpoint.memory_region)
+                .map_err(|e| {
+                    io::Error::other(format!("Failed to parse controller req memory: {}", e))
+                })?;
+        let controller_resp_endpoint: QueuePairEndpoint =
+            serde_json::from_str(&controller_connection_pair.response_endpoint.qp_endpoint)
+                .map_err(|e| {
+                    io::Error::other(format!("Failed to parse controller resp endpoint: {}", e))
+                })?;
+        let controller_resp_memory: RemoteMemoryRegion =
+            serde_json::from_str(&controller_connection_pair.response_endpoint.memory_region)
+                .map_err(|e| {
+                    io::Error::other(format!("Failed to parse controller resp memory: {}", e))
+                })?;
 
         // Establish RDMA connections
         log::info!("🔗 Establishing RDMA connections with controller");
@@ -185,10 +226,10 @@ impl RdmaEndpointServer {
         }
 
         log::info!("✅ RDMA bidirectional connection established successfully");
-        
+
         // Update global connection status
         crate::worker::update_rdma_connection_status(true);
-        
+
         Ok(())
     }
 }
@@ -205,7 +246,10 @@ impl RdmaEndpointClient {
         controller_resp_queue: Arc<tokio::sync::Mutex<RdmaQueue<ShmqWorkerResp>>>,
     ) -> io::Result<()> {
         let worker_addr = format!("{}:{}", worker_host, worker_tcp_port);
-        log::info!("🔗 Connecting to worker at {} for RDMA endpoint exchange", worker_addr);
+        log::info!(
+            "🔗 Connecting to worker at {} for RDMA endpoint exchange",
+            worker_addr
+        );
 
         let stream = TcpStream::connect(&worker_addr)?;
         log::info!("✅ Connected to worker TCP server");
@@ -214,7 +258,7 @@ impl RdmaEndpointClient {
         let controller_connection_pair = {
             let req_guard = controller_req_queue.lock().await;
             let resp_guard = controller_resp_queue.lock().await;
-            
+
             let req_endpoint = req_guard.endpoint()?;
             let req_memory = req_guard.memory_region();
             let resp_endpoint = resp_guard.endpoint()?;
@@ -222,16 +266,20 @@ impl RdmaEndpointClient {
 
             RdmaConnectionPair {
                 request_endpoint: RdmaConnectionInfo {
-                    qp_endpoint: serde_json::to_string(&req_endpoint)
-                        .map_err(|e| io::Error::other(format!("Failed to serialize req endpoint: {}", e)))?,
-                    memory_region: serde_json::to_string(&req_memory)
-                        .map_err(|e| io::Error::other(format!("Failed to serialize req memory: {}", e)))?,
+                    qp_endpoint: serde_json::to_string(&req_endpoint).map_err(|e| {
+                        io::Error::other(format!("Failed to serialize req endpoint: {}", e))
+                    })?,
+                    memory_region: serde_json::to_string(&req_memory).map_err(|e| {
+                        io::Error::other(format!("Failed to serialize req memory: {}", e))
+                    })?,
                 },
                 response_endpoint: RdmaConnectionInfo {
-                    qp_endpoint: serde_json::to_string(&resp_endpoint)
-                        .map_err(|e| io::Error::other(format!("Failed to serialize resp endpoint: {}", e)))?,
-                    memory_region: serde_json::to_string(&resp_memory)
-                        .map_err(|e| io::Error::other(format!("Failed to serialize resp memory: {}", e)))?,
+                    qp_endpoint: serde_json::to_string(&resp_endpoint).map_err(|e| {
+                        io::Error::other(format!("Failed to serialize resp endpoint: {}", e))
+                    })?,
+                    memory_region: serde_json::to_string(&resp_memory).map_err(|e| {
+                        io::Error::other(format!("Failed to serialize resp memory: {}", e))
+                    })?,
                 },
             }
         };
@@ -240,8 +288,9 @@ impl RdmaEndpointClient {
         let mut reader = BufReader::new(&stream);
         let mut worker_info_line = String::new();
         reader.read_line(&mut worker_info_line)?;
-        let worker_connection_pair: RdmaConnectionPair = serde_json::from_str(worker_info_line.trim())
-            .map_err(|e| io::Error::other(format!("Failed to parse worker info: {}", e)))?;
+        let worker_connection_pair: RdmaConnectionPair =
+            serde_json::from_str(worker_info_line.trim())
+                .map_err(|e| io::Error::other(format!("Failed to parse worker info: {}", e)))?;
         log::info!("📥 Received worker RDMA endpoints");
 
         // Send controller's endpoints to worker
@@ -253,14 +302,22 @@ impl RdmaEndpointClient {
         log::info!("📤 Sent controller RDMA endpoints to worker");
 
         // Parse worker endpoints
-        let worker_req_endpoint: QueuePairEndpoint = serde_json::from_str(&worker_connection_pair.request_endpoint.qp_endpoint)
-            .map_err(|e| io::Error::other(format!("Failed to parse worker req endpoint: {}", e)))?;
-        let worker_req_memory: RemoteMemoryRegion = serde_json::from_str(&worker_connection_pair.request_endpoint.memory_region)
-            .map_err(|e| io::Error::other(format!("Failed to parse worker req memory: {}", e)))?;
-        let worker_resp_endpoint: QueuePairEndpoint = serde_json::from_str(&worker_connection_pair.response_endpoint.qp_endpoint)
-            .map_err(|e| io::Error::other(format!("Failed to parse worker resp endpoint: {}", e)))?;
-        let worker_resp_memory: RemoteMemoryRegion = serde_json::from_str(&worker_connection_pair.response_endpoint.memory_region)
-            .map_err(|e| io::Error::other(format!("Failed to parse worker resp memory: {}", e)))?;
+        let worker_req_endpoint: QueuePairEndpoint = serde_json::from_str(
+            &worker_connection_pair.request_endpoint.qp_endpoint,
+        )
+        .map_err(|e| io::Error::other(format!("Failed to parse worker req endpoint: {}", e)))?;
+        let worker_req_memory: RemoteMemoryRegion = serde_json::from_str(
+            &worker_connection_pair.request_endpoint.memory_region,
+        )
+        .map_err(|e| io::Error::other(format!("Failed to parse worker req memory: {}", e)))?;
+        let worker_resp_endpoint: QueuePairEndpoint = serde_json::from_str(
+            &worker_connection_pair.response_endpoint.qp_endpoint,
+        )
+        .map_err(|e| io::Error::other(format!("Failed to parse worker resp endpoint: {}", e)))?;
+        let worker_resp_memory: RemoteMemoryRegion = serde_json::from_str(
+            &worker_connection_pair.response_endpoint.memory_region,
+        )
+        .map_err(|e| io::Error::other(format!("Failed to parse worker resp memory: {}", e)))?;
 
         // Establish RDMA connections
         log::info!("🔗 Establishing RDMA connections with worker");
@@ -297,7 +354,7 @@ impl RdmaEndpointClient {
         stream.flush()?;
 
         log::info!("✅ RDMA bidirectional connection established successfully");
-        
+
         Ok(())
     }
 }

--- a/ek-computation/src/shmq/rdma_tcp_exchange.rs
+++ b/ek-computation/src/shmq/rdma_tcp_exchange.rs
@@ -83,7 +83,7 @@ impl RdmaEndpointServer {
                     let handle = std::thread::spawn(move || {
                         Self::handle_connection(stream, req_queue, resp_queue)
                     });
-                    
+
                     // Wait for completion
                     let result = handle.join();
 

--- a/ek-computation/src/shmq/rdma_tcp_exchange.rs
+++ b/ek-computation/src/shmq/rdma_tcp_exchange.rs
@@ -1,0 +1,292 @@
+use std::io::{self, BufRead, BufReader, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use serde::{Serialize, Deserialize};
+use ibverbs::{QueuePairEndpoint, RemoteMemoryRegion};
+
+use crate::controller::registry::{ShmqWorkerReq, ShmqWorkerResp};
+use super::rdma_impl::RdmaQueue;
+
+/// Connection information exchanged over TCP
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct RdmaConnectionInfo {
+    pub qp_endpoint: String,
+    pub memory_region: String,
+}
+
+/// Pair of connection info for bidirectional communication
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct RdmaConnectionPair {
+    pub request_endpoint: RdmaConnectionInfo,
+    pub response_endpoint: RdmaConnectionInfo,
+}
+
+/// TCP server for RDMA endpoint exchange (worker side)
+pub struct RdmaEndpointServer {
+    pub tcp_port: u16,
+    req_queue: Arc<Mutex<RdmaQueue<ShmqWorkerReq>>>,
+    resp_queue: Arc<Mutex<RdmaQueue<ShmqWorkerResp>>>,
+}
+
+impl RdmaEndpointServer {
+    /// Create new RDMA endpoint server with queues
+    pub fn new(
+        req_queue: Arc<Mutex<RdmaQueue<ShmqWorkerReq>>>,
+        resp_queue: Arc<Mutex<RdmaQueue<ShmqWorkerResp>>>,
+    ) -> io::Result<Self> {
+        // Bind to any available port
+        let listener = TcpListener::bind("0.0.0.0:0")?;
+        let tcp_port = listener.local_addr()?.port();
+        drop(listener); // Release the port for actual use
+        
+        Ok(Self {
+            tcp_port,
+            req_queue,
+            resp_queue,
+        })
+    }
+
+    /// Get the TCP port for controller to connect
+    pub fn port(&self) -> u16 {
+        self.tcp_port
+    }
+
+    /// Start TCP server to handle RDMA endpoint exchange
+    pub async fn start(&self) -> io::Result<()> {
+        let listener = TcpListener::bind(format!("0.0.0.0:{}", self.tcp_port))?;
+        log::info!("🌐 RDMA endpoint exchange server listening on port {}", self.tcp_port);
+
+        loop {
+            match listener.accept() {
+                Ok((stream, addr)) => {
+                    log::info!("📡 Controller connected from: {}", addr);
+                    
+                    let req_queue = self.req_queue.clone();
+                    let resp_queue = self.resp_queue.clone();
+                    
+                    // Handle connection in background
+                    tokio::task::spawn_blocking(move || {
+                        if let Err(e) = Self::handle_connection(stream, req_queue, resp_queue) {
+                            log::error!("Failed to handle RDMA endpoint exchange: {}", e);
+                        }
+                    });
+                }
+                Err(e) => {
+                    log::error!("Failed to accept TCP connection: {}", e);
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+            }
+        }
+    }
+
+    /// Handle single TCP connection for endpoint exchange
+    fn handle_connection(
+        mut stream: TcpStream,
+        req_queue: Arc<Mutex<RdmaQueue<ShmqWorkerReq>>>,
+        resp_queue: Arc<Mutex<RdmaQueue<ShmqWorkerResp>>>,
+    ) -> io::Result<()> {
+        log::info!("🔄 Starting RDMA endpoint exchange");
+
+        // Get worker's RDMA endpoints
+        let worker_connection_pair = {
+            let req_guard = req_queue.lock().unwrap();
+            let resp_guard = resp_queue.lock().unwrap();
+            
+            let req_endpoint = req_guard.endpoint()?;
+            let req_memory = req_guard.memory_region();
+            let resp_endpoint = resp_guard.endpoint()?;
+            let resp_memory = resp_guard.memory_region();
+
+            RdmaConnectionPair {
+                request_endpoint: RdmaConnectionInfo {
+                    qp_endpoint: serde_json::to_string(&req_endpoint)
+                        .map_err(|e| io::Error::other(format!("Failed to serialize req endpoint: {}", e)))?,
+                    memory_region: serde_json::to_string(&req_memory)
+                        .map_err(|e| io::Error::other(format!("Failed to serialize req memory: {}", e)))?,
+                },
+                response_endpoint: RdmaConnectionInfo {
+                    qp_endpoint: serde_json::to_string(&resp_endpoint)
+                        .map_err(|e| io::Error::other(format!("Failed to serialize resp endpoint: {}", e)))?,
+                    memory_region: serde_json::to_string(&resp_memory)
+                        .map_err(|e| io::Error::other(format!("Failed to serialize resp memory: {}", e)))?,
+                },
+            }
+        };
+
+        // Send worker's endpoints to controller
+        let worker_info_json = serde_json::to_string(&worker_connection_pair)
+            .map_err(|e| io::Error::other(format!("Failed to serialize worker info: {}", e)))?;
+        writeln!(stream, "{}", worker_info_json)?;
+        stream.flush()?;
+        log::info!("📤 Sent worker RDMA endpoints to controller");
+
+        // Receive controller's endpoints
+        let mut reader = BufReader::new(&stream);
+        let mut controller_info_line = String::new();
+        reader.read_line(&mut controller_info_line)?;
+        let controller_connection_pair: RdmaConnectionPair = serde_json::from_str(controller_info_line.trim())
+            .map_err(|e| io::Error::other(format!("Failed to parse controller info: {}", e)))?;
+        log::info!("📥 Received controller RDMA endpoints");
+
+        // Parse controller endpoints
+        let controller_req_endpoint: QueuePairEndpoint = serde_json::from_str(&controller_connection_pair.request_endpoint.qp_endpoint)
+            .map_err(|e| io::Error::other(format!("Failed to parse controller req endpoint: {}", e)))?;
+        let controller_req_memory: RemoteMemoryRegion = serde_json::from_str(&controller_connection_pair.request_endpoint.memory_region)
+            .map_err(|e| io::Error::other(format!("Failed to parse controller req memory: {}", e)))?;
+        let controller_resp_endpoint: QueuePairEndpoint = serde_json::from_str(&controller_connection_pair.response_endpoint.qp_endpoint)
+            .map_err(|e| io::Error::other(format!("Failed to parse controller resp endpoint: {}", e)))?;
+        let controller_resp_memory: RemoteMemoryRegion = serde_json::from_str(&controller_connection_pair.response_endpoint.memory_region)
+            .map_err(|e| io::Error::other(format!("Failed to parse controller resp memory: {}", e)))?;
+
+        // Establish RDMA connections
+        log::info!("🔗 Establishing RDMA connections with controller");
+
+        // Connect worker's request queue to controller's request queue (for receiving requests)
+        {
+            let mut req_queue_lock = req_queue.lock().unwrap();
+            if !req_queue_lock.is_connected() {
+                req_queue_lock.connect(controller_req_endpoint, controller_req_memory)?;
+                log::info!("🚀 Worker request queue connected to controller");
+            }
+        }
+
+        // Connect worker's response queue to controller's response queue (for sending responses)
+        {
+            let mut resp_queue_lock = resp_queue.lock().unwrap();
+            if !resp_queue_lock.is_connected() {
+                resp_queue_lock.connect(controller_resp_endpoint, controller_resp_memory)?;
+                log::info!("🚀 Worker response queue connected to controller");
+            }
+        }
+
+        // Signal successful connection
+        let mut stream = reader.into_inner();
+        writeln!(stream, "RDMA_READY")?;
+        stream.flush()?;
+
+        // Wait for controller ready signal
+        let mut final_reader = BufReader::new(stream);
+        let mut ready_line = String::new();
+        final_reader.read_line(&mut ready_line)?;
+        if ready_line.trim() != "RDMA_READY" {
+            return Err(io::Error::other("Controller not ready"));
+        }
+
+        log::info!("✅ RDMA bidirectional connection established successfully");
+        
+        // Update global connection status
+        crate::worker::update_rdma_connection_status(true);
+        
+        Ok(())
+    }
+}
+
+/// TCP client for RDMA endpoint exchange (controller side)
+pub struct RdmaEndpointClient;
+
+impl RdmaEndpointClient {
+    /// Connect to worker and exchange RDMA endpoints
+    pub async fn connect_and_exchange(
+        worker_host: &str,
+        worker_tcp_port: u16,
+        controller_req_queue: Arc<tokio::sync::Mutex<RdmaQueue<ShmqWorkerReq>>>,
+        controller_resp_queue: Arc<tokio::sync::Mutex<RdmaQueue<ShmqWorkerResp>>>,
+    ) -> io::Result<()> {
+        let worker_addr = format!("{}:{}", worker_host, worker_tcp_port);
+        log::info!("🔗 Connecting to worker at {} for RDMA endpoint exchange", worker_addr);
+
+        let mut stream = TcpStream::connect(&worker_addr)?;
+        log::info!("✅ Connected to worker TCP server");
+
+        // Get controller's RDMA endpoints
+        let controller_connection_pair = {
+            let req_guard = controller_req_queue.lock().await;
+            let resp_guard = controller_resp_queue.lock().await;
+            
+            let req_endpoint = req_guard.endpoint()?;
+            let req_memory = req_guard.memory_region();
+            let resp_endpoint = resp_guard.endpoint()?;
+            let resp_memory = resp_guard.memory_region();
+
+            RdmaConnectionPair {
+                request_endpoint: RdmaConnectionInfo {
+                    qp_endpoint: serde_json::to_string(&req_endpoint)
+                        .map_err(|e| io::Error::other(format!("Failed to serialize req endpoint: {}", e)))?,
+                    memory_region: serde_json::to_string(&req_memory)
+                        .map_err(|e| io::Error::other(format!("Failed to serialize req memory: {}", e)))?,
+                },
+                response_endpoint: RdmaConnectionInfo {
+                    qp_endpoint: serde_json::to_string(&resp_endpoint)
+                        .map_err(|e| io::Error::other(format!("Failed to serialize resp endpoint: {}", e)))?,
+                    memory_region: serde_json::to_string(&resp_memory)
+                        .map_err(|e| io::Error::other(format!("Failed to serialize resp memory: {}", e)))?,
+                },
+            }
+        };
+
+        // Receive worker's endpoints first
+        let mut reader = BufReader::new(&stream);
+        let mut worker_info_line = String::new();
+        reader.read_line(&mut worker_info_line)?;
+        let worker_connection_pair: RdmaConnectionPair = serde_json::from_str(worker_info_line.trim())
+            .map_err(|e| io::Error::other(format!("Failed to parse worker info: {}", e)))?;
+        log::info!("📥 Received worker RDMA endpoints");
+
+        // Send controller's endpoints to worker
+        let mut stream = reader.into_inner();
+        let controller_info_json = serde_json::to_string(&controller_connection_pair)
+            .map_err(|e| io::Error::other(format!("Failed to serialize controller info: {}", e)))?;
+        writeln!(stream, "{}", controller_info_json)?;
+        stream.flush()?;
+        log::info!("📤 Sent controller RDMA endpoints to worker");
+
+        // Parse worker endpoints
+        let worker_req_endpoint: QueuePairEndpoint = serde_json::from_str(&worker_connection_pair.request_endpoint.qp_endpoint)
+            .map_err(|e| io::Error::other(format!("Failed to parse worker req endpoint: {}", e)))?;
+        let worker_req_memory: RemoteMemoryRegion = serde_json::from_str(&worker_connection_pair.request_endpoint.memory_region)
+            .map_err(|e| io::Error::other(format!("Failed to parse worker req memory: {}", e)))?;
+        let worker_resp_endpoint: QueuePairEndpoint = serde_json::from_str(&worker_connection_pair.response_endpoint.qp_endpoint)
+            .map_err(|e| io::Error::other(format!("Failed to parse worker resp endpoint: {}", e)))?;
+        let worker_resp_memory: RemoteMemoryRegion = serde_json::from_str(&worker_connection_pair.response_endpoint.memory_region)
+            .map_err(|e| io::Error::other(format!("Failed to parse worker resp memory: {}", e)))?;
+
+        // Establish RDMA connections
+        log::info!("🔗 Establishing RDMA connections with worker");
+
+        // Connect controller's request queue to worker's request queue (for sending requests)
+        {
+            let mut req_queue_lock = controller_req_queue.lock().await;
+            if !req_queue_lock.is_connected() {
+                req_queue_lock.connect(worker_req_endpoint, worker_req_memory)?;
+                log::info!("🚀 Controller request queue connected to worker");
+            }
+        }
+
+        // Connect controller's response queue to worker's response queue (for receiving responses)
+        {
+            let mut resp_queue_lock = controller_resp_queue.lock().await;
+            if !resp_queue_lock.is_connected() {
+                resp_queue_lock.connect(worker_resp_endpoint, worker_resp_memory)?;
+                log::info!("🚀 Controller response queue connected to worker");
+            }
+        }
+
+        // Wait for worker ready signal
+        let mut ready_reader = BufReader::new(stream);
+        let mut ready_line = String::new();
+        ready_reader.read_line(&mut ready_line)?;
+        if ready_line.trim() != "RDMA_READY" {
+            return Err(io::Error::other("Worker not ready"));
+        }
+
+        // Signal controller ready
+        let mut stream = ready_reader.into_inner();
+        writeln!(stream, "RDMA_READY")?;
+        stream.flush()?;
+
+        log::info!("✅ RDMA bidirectional connection established successfully");
+        
+        Ok(())
+    }
+}

--- a/ek-computation/src/worker/mod.rs
+++ b/ek-computation/src/worker/mod.rs
@@ -20,8 +20,10 @@ pub mod x;
 
 use crate::controller::registry::{ShmqWorkerReq, ShmqWorkerResp};
 use crate::metrics::spawn_metrics_server;
+use crate::proto::ek::worker::v1::computation_service_server::ComputationServiceServer;
 use crate::shmq::{RdmaEndpointServer, ShmQueue, rdma_impl::RdmaQueue};
 use crate::worker::core::EKInstanceGateSync;
+use crate::worker::server::BasicExpertImpl;
 use crate::x::get_graceful_shutdown_ch;
 
 use super::worker::state::StateClient;
@@ -32,6 +34,11 @@ static RDMA_REQ_QUEUE: OnceLock<Arc<Mutex<RdmaQueue<ShmqWorkerReq>>>> = OnceLock
 static RDMA_RESP_QUEUE: OnceLock<Arc<Mutex<RdmaQueue<ShmqWorkerResp>>>> = OnceLock::new();
 static RDMA_CONNECTION_STATUS: AtomicBool = AtomicBool::new(false);
 static RDMA_TCP_PORT: OnceLock<u16> = OnceLock::new();
+static WORKER_PARALLEL: LazyLock<usize> = LazyLock::new(|| {
+    env::var("EK_WORKER_PARALLEL")
+        .map(|v| v.parse().unwrap_or(1))
+        .unwrap_or(1)
+});
 
 /// Get the global RDMA request queue
 pub fn get_rdma_req_queue() -> Option<&'static Arc<Mutex<RdmaQueue<ShmqWorkerReq>>>> {
@@ -52,13 +59,27 @@ pub fn update_rdma_connection_status(connected: bool) {
     RDMA_CONNECTION_STATUS.store(connected, Ordering::Relaxed);
 }
 
+pub fn close_rdma_queues() {
+    if let Some(req_queue) = RDMA_REQ_QUEUE.get() {
+        let mut rq = req_queue.lock().unwrap();
+        rq.disconnect();
+    }
+    if let Some(resp_queue) = RDMA_RESP_QUEUE.get() {
+        let mut rq = resp_queue.lock().unwrap();
+        rq.disconnect();
+    }
+    update_rdma_connection_status(false);
+}
+
 /// Get the global RDMA TCP port
 pub fn get_rdma_tcp_port() -> Option<u16> {
     RDMA_TCP_PORT.get().copied()
 }
 
 /// Create RDMA queues and start TCP server for endpoint exchange
-async fn create_rdma_queues_with_tcp_server() -> EKResult<(u16, tokio::task::JoinHandle<()>)> {
+async fn create_rdma_queues_with_tcp_server(
+    poison: Arc<Mutex<bool>>,
+) -> EKResult<(u16, std::thread::JoinHandle<()>)> {
     // Worker receives requests (sender=false) and sends responses (sender=true)
     let req_queue = RdmaQueue::<ShmqWorkerReq>::new(None, 256, false)?;
     let resp_queue = RdmaQueue::<ShmqWorkerResp>::new(None, 256, true)?;
@@ -75,7 +96,7 @@ async fn create_rdma_queues_with_tcp_server() -> EKResult<(u16, tokio::task::Joi
     })?;
 
     // Create TCP server for endpoint exchange
-    let endpoint_server = RdmaEndpointServer::new(req_queue_arc, resp_queue_arc)
+    let endpoint_server = RdmaEndpointServer::new(req_queue_arc, resp_queue_arc, poison)
         .map_err(|e| ek_base::error::EKError::IoError(e))?;
     let tcp_port = endpoint_server.port();
 
@@ -85,27 +106,17 @@ async fn create_rdma_queues_with_tcp_server() -> EKResult<(u16, tokio::task::Joi
         .map_err(|_| ek_base::error::EKError::InvalidInput("Failed to set RDMA TCP port".into()))?;
 
     // Start the TCP server and return its handle
-    let endpoint_server_handle = tokio::spawn(async move {
-        match endpoint_server.start().await {
-            Ok(()) => {
-                log::info!("🎯 RDMA TCP endpoint server completed successfully");
-            }
-            Err(e) => {
-                log::error!("RDMA TCP endpoint server failed: {}", e);
-            }
+    let endpoint_server_handle = std::thread::spawn(move || match endpoint_server.start() {
+        Ok(()) => {
+            log::info!("RDMA TCP endpoint server completed successfully");
+        }
+        Err(e) => {
+            log::error!("RDMA TCP endpoint server failed: {}", e);
         }
     });
 
     Ok((tcp_port, endpoint_server_handle))
 }
-use crate::proto::ek::worker::v1::computation_service_server::ComputationServiceServer;
-use crate::worker::server::BasicExpertImpl;
-
-static WORKER_PARALLEL: LazyLock<usize> = LazyLock::new(|| {
-    env::var("EK_WORKER_PARALLEL")
-        .map(|v| v.parse().unwrap_or(1))
-        .unwrap_or(1)
-});
 
 /// Main worker entry point
 pub async fn worker_main() -> EKResult<()> {
@@ -116,16 +127,24 @@ pub async fn worker_main() -> EKResult<()> {
     let token = CancellationToken::new();
     let cli_cancel = token.clone();
 
+    // Create poison flag for graceful shutdown
+    let poison = Arc::new(Mutex::new(false));
+
+    // Spawn state inspector task (monitors loading progress)
+    let state_inspect = StateInspector::spawn();
+
+    let async_srv;
+    let mut sync_srvs = Vec::new();
+    tch::set_num_threads(*WORKER_PARALLEL as _);
+
     // Determine queue type based on configuration
     // Note: Channel should be created before stateClient start for endpoint exchange
-    let (rdma_tcp_port, endpoint_server_handle): (
-        Option<u16>,
-        Option<tokio::task::JoinHandle<()>>,
-    ) = if settings.worker.channel == "rdma" {
-        match create_rdma_queues_with_tcp_server().await {
+    let rdma_tcp_port: Option<u16> = if settings.worker.channel == "rdma" {
+        match create_rdma_queues_with_tcp_server(poison.clone()).await {
             Ok((tcp_port, handle)) => {
                 log::info!("RDMA queues and TCP server created successfully");
-                (Some(tcp_port), Some(handle))
+                sync_srvs.push(handle);
+                Some(tcp_port)
             }
             Err(e) => {
                 log::error!("Failed to create RDMA queues: {e}");
@@ -133,7 +152,7 @@ pub async fn worker_main() -> EKResult<()> {
             }
         }
     } else {
-        (None, None)
+        None
     };
 
     // Spawn state client task (handles expert loading/unloading)
@@ -148,14 +167,6 @@ pub async fn worker_main() -> EKResult<()> {
             log::error!("state client error {e:}");
         }
     });
-
-    // Spawn state inspector task (monitors loading progress)
-    let state_inspect = StateInspector::spawn();
-
-    let async_srv;
-    let mut sync_srvs = Vec::new();
-    let poison = Arc::new(Mutex::new(false));
-    tch::set_num_threads(*WORKER_PARALLEL as _);
 
     match settings.worker.channel.as_str() {
         "grpc" => {
@@ -371,14 +382,6 @@ pub async fn worker_main() -> EKResult<()> {
             log::info!("ctrl-c signal received, shutting down");
             *poison.lock().unwrap() = true;
             token.clone().cancel();
-
-            // Wait for RDMA endpoint server to complete if it exists
-            if let Some(handle) = endpoint_server_handle {
-                log::info!("Waiting for RDMA endpoint server to complete...");
-                if let Err(e) = handle.await {
-                    log::error!("RDMA endpoint server task failed: {}", e);
-                }
-            }
 
             let(_,rx) = get_graceful_shutdown_ch();
             rx.lock().await.recv().await;

--- a/ek-computation/src/worker/mod.rs
+++ b/ek-computation/src/worker/mod.rs
@@ -58,7 +58,7 @@ pub fn get_rdma_tcp_port() -> Option<u16> {
 }
 
 /// Create RDMA queues and start TCP server for endpoint exchange
-async fn create_rdma_queues_with_tcp_server() -> EKResult<u16> {
+async fn create_rdma_queues_with_tcp_server() -> EKResult<(u16, tokio::task::JoinHandle<()>)> {
     // Worker receives requests (sender=false) and sends responses (sender=true)
     let req_queue = RdmaQueue::<ShmqWorkerReq>::new(None, 256, false)?;
     let resp_queue = RdmaQueue::<ShmqWorkerResp>::new(None, 256, true)?;
@@ -90,16 +90,21 @@ async fn create_rdma_queues_with_tcp_server() -> EKResult<u16> {
             ek_base::error::EKError::InvalidInput("Failed to set RDMA TCP port".into())
         })?;
 
-    // Start the TCP server in background
-    tokio::spawn(async move {
-        if let Err(e) = endpoint_server.start().await {
-            log::error!("RDMA TCP endpoint server failed: {}", e);
+    // Start the TCP server and return its handle
+    let endpoint_server_handle = tokio::spawn(async move {
+        match endpoint_server.start().await {
+            Ok(()) => {
+                log::info!("🎯 RDMA TCP endpoint server completed successfully");
+            }
+            Err(e) => {
+                log::error!("RDMA TCP endpoint server failed: {}", e);
+            }
         }
     });
 
     log::info!("🌐 RDMA TCP endpoint exchange server started on port {}", tcp_port);
     
-    Ok(tcp_port)
+    Ok((tcp_port, endpoint_server_handle))
 }
 use crate::proto::ek::worker::v1::computation_service_server::ComputationServiceServer;
 use crate::worker::server::BasicExpertImpl;
@@ -121,11 +126,11 @@ pub async fn worker_main() -> EKResult<()> {
 
     // Determine queue type based on configuration
     // Note: Channel should be created before stateClient start for endpoint exchange
-    let rdma_tcp_port: Option<u16> = if settings.worker.channel == "rdma" {
+    let (rdma_tcp_port, endpoint_server_handle): (Option<u16>, Option<tokio::task::JoinHandle<()>>) = if settings.worker.channel == "rdma" {
         match create_rdma_queues_with_tcp_server().await {
-            Ok(tcp_port) => {
+            Ok((tcp_port, handle)) => {
                 log::info!("RDMA queues and TCP server created successfully");
-                Some(tcp_port)
+                (Some(tcp_port), Some(handle))
             }
             Err(e) => {
                 log::error!("Failed to create RDMA queues: {e}");
@@ -133,7 +138,7 @@ pub async fn worker_main() -> EKResult<()> {
             }
         }
     } else {
-        None
+        (None, None)
     };
 
     // Spawn state client task (handles expert loading/unloading)
@@ -371,6 +376,15 @@ pub async fn worker_main() -> EKResult<()> {
             log::info!("ctrl-c signal received, shutting down");
             *poison.lock().unwrap() = true;
             token.clone().cancel();
+            
+            // Wait for RDMA endpoint server to complete if it exists
+            if let Some(handle) = endpoint_server_handle {
+                log::info!("Waiting for RDMA endpoint server to complete...");
+                if let Err(e) = handle.await {
+                    log::error!("RDMA endpoint server task failed: {}", e);
+                }
+            }
+            
             let(_,rx) = get_graceful_shutdown_ch();
             rx.lock().await.recv().await;
             for srv in sync_srvs {

--- a/ek-computation/src/worker/mod.rs
+++ b/ek-computation/src/worker/mod.rs
@@ -20,18 +20,18 @@ pub mod x;
 
 use crate::controller::registry::{ShmqWorkerReq, ShmqWorkerResp};
 use crate::metrics::spawn_metrics_server;
-use crate::shmq::{ShmQueue, rdma_impl::RdmaQueue};
+use crate::shmq::{ShmQueue, rdma_impl::RdmaQueue, RdmaEndpointServer};
 use crate::worker::core::EKInstanceGateSync;
 use crate::x::get_graceful_shutdown_ch;
 
 use super::worker::state::StateClient;
-use crate::proto::ek::worker::v1::{RdmaEndpoint, RdmaEndpointPair};
 use ek_base::{config::get_ek_settings, error::EKResult};
 
-// Global storage for RDMA queues
+// Global storage for RDMA queues and TCP server
 static RDMA_REQ_QUEUE: OnceLock<Arc<Mutex<RdmaQueue<ShmqWorkerReq>>>> = OnceLock::new();
 static RDMA_RESP_QUEUE: OnceLock<Arc<Mutex<RdmaQueue<ShmqWorkerResp>>>> = OnceLock::new();
 static RDMA_CONNECTION_STATUS: AtomicBool = AtomicBool::new(false);
+static RDMA_TCP_PORT: OnceLock<u16> = OnceLock::new();
 
 /// Get the global RDMA request queue
 pub fn get_rdma_req_queue() -> Option<&'static Arc<Mutex<RdmaQueue<ShmqWorkerReq>>>> {
@@ -52,56 +52,54 @@ pub fn update_rdma_connection_status(connected: bool) {
     RDMA_CONNECTION_STATUS.store(connected, Ordering::Relaxed);
 }
 
-/// Create RDMA queues and return endpoint information
-async fn create_rdma_queues() -> EKResult<RdmaEndpointPair> {
+/// Get the global RDMA TCP port
+pub fn get_rdma_tcp_port() -> Option<u16> {
+    RDMA_TCP_PORT.get().copied()
+}
+
+/// Create RDMA queues and start TCP server for endpoint exchange
+async fn create_rdma_queues_with_tcp_server() -> EKResult<u16> {
     // Worker receives requests (sender=false) and sends responses (sender=true)
     let req_queue = RdmaQueue::<ShmqWorkerReq>::new(None, 256, false)?;
     let resp_queue = RdmaQueue::<ShmqWorkerResp>::new(None, 256, true)?;
 
-    let req_endpoint = req_queue.endpoint()?;
-    let req_memory = req_queue.memory_region();
-    let resp_endpoint = resp_queue.endpoint()?;
-    let resp_memory = resp_queue.memory_region();
+    let req_queue_arc = Arc::new(Mutex::new(req_queue));
+    let resp_queue_arc = Arc::new(Mutex::new(resp_queue));
 
     // Store the queues globally
     RDMA_REQ_QUEUE
-        .set(Arc::new(Mutex::new(req_queue)))
+        .set(req_queue_arc.clone())
         .map_err(|_| {
             ek_base::error::EKError::InvalidInput("Failed to set RDMA request queue".into())
         })?;
     RDMA_RESP_QUEUE
-        .set(Arc::new(Mutex::new(resp_queue)))
+        .set(resp_queue_arc.clone())
         .map_err(|_| {
             ek_base::error::EKError::InvalidInput("Failed to set RDMA response queue".into())
         })?;
 
-    // Serialize endpoint and memory region data as JSON strings
-    let req_endpoint_json = serde_json::to_string(&req_endpoint).map_err(|e| {
-        ek_base::error::EKError::InvalidInput(format!("Failed to serialize QP endpoint: {e}"))
-    })?;
+    // Create TCP server for endpoint exchange
+    let endpoint_server = RdmaEndpointServer::new(req_queue_arc, resp_queue_arc)
+        .map_err(|e| ek_base::error::EKError::IoError(e))?;
+    let tcp_port = endpoint_server.port();
+    
+    // Store TCP port globally
+    RDMA_TCP_PORT
+        .set(tcp_port)
+        .map_err(|_| {
+            ek_base::error::EKError::InvalidInput("Failed to set RDMA TCP port".into())
+        })?;
 
-    let req_memory_json = serde_json::to_string(&req_memory).map_err(|e| {
-        ek_base::error::EKError::InvalidInput(format!("Failed to serialize memory region: {e}"))
-    })?;
+    // Start the TCP server in background
+    tokio::spawn(async move {
+        if let Err(e) = endpoint_server.start().await {
+            log::error!("RDMA TCP endpoint server failed: {}", e);
+        }
+    });
 
-    let resp_endpoint_json = serde_json::to_string(&resp_endpoint).map_err(|e| {
-        ek_base::error::EKError::InvalidInput(format!("Failed to serialize QP endpoint: {e}"))
-    })?;
-
-    let resp_memory_json = serde_json::to_string(&resp_memory).map_err(|e| {
-        ek_base::error::EKError::InvalidInput(format!("Failed to serialize memory region: {e}"))
-    })?;
-
-    Ok(RdmaEndpointPair {
-        request_endpoint: Some(RdmaEndpoint {
-            qp_endpoint: req_endpoint_json,
-            memory_region: req_memory_json,
-        }),
-        response_endpoint: Some(RdmaEndpoint {
-            qp_endpoint: resp_endpoint_json,
-            memory_region: resp_memory_json,
-        }),
-    })
+    log::info!("🌐 RDMA TCP endpoint exchange server started on port {}", tcp_port);
+    
+    Ok(tcp_port)
 }
 use crate::proto::ek::worker::v1::computation_service_server::ComputationServiceServer;
 use crate::worker::server::BasicExpertImpl;
@@ -123,11 +121,11 @@ pub async fn worker_main() -> EKResult<()> {
 
     // Determine queue type based on configuration
     // Note: Channel should be created before stateClient start for endpoint exchange
-    let rdma_endpoints: Option<RdmaEndpointPair> = if settings.worker.channel == "rdma" {
-        match create_rdma_queues().await {
-            Ok(endpoint_pair) => {
-                log::info!("RDMA queues created successfully");
-                Some(endpoint_pair)
+    let rdma_tcp_port: Option<u16> = if settings.worker.channel == "rdma" {
+        match create_rdma_queues_with_tcp_server().await {
+            Ok(tcp_port) => {
+                log::info!("RDMA queues and TCP server created successfully");
+                Some(tcp_port)
             }
             Err(e) => {
                 log::error!("Failed to create RDMA queues: {e}");
@@ -145,7 +143,7 @@ pub async fn worker_main() -> EKResult<()> {
         let control_endpoint = x::get_controller_addr();
         log::info!("control endpoint {:}", control_endpoint.uri());
         let mut state_client =
-            StateClient::new_with_rdma(control_endpoint, &worker_id, rdma_endpoints);
+            StateClient::new_with_rdma_tcp_port(control_endpoint, &worker_id, rdma_tcp_port);
         if let Err(e) = state_client.run(cli_cancel).await {
             log::error!("state client error {e:}");
         }

--- a/ek-computation/src/worker/mod.rs
+++ b/ek-computation/src/worker/mod.rs
@@ -20,7 +20,7 @@ pub mod x;
 
 use crate::controller::registry::{ShmqWorkerReq, ShmqWorkerResp};
 use crate::metrics::spawn_metrics_server;
-use crate::shmq::{ShmQueue, rdma_impl::RdmaQueue, RdmaEndpointServer};
+use crate::shmq::{RdmaEndpointServer, ShmQueue, rdma_impl::RdmaQueue};
 use crate::worker::core::EKInstanceGateSync;
 use crate::x::get_graceful_shutdown_ch;
 
@@ -67,28 +67,22 @@ async fn create_rdma_queues_with_tcp_server() -> EKResult<(u16, tokio::task::Joi
     let resp_queue_arc = Arc::new(Mutex::new(resp_queue));
 
     // Store the queues globally
-    RDMA_REQ_QUEUE
-        .set(req_queue_arc.clone())
-        .map_err(|_| {
-            ek_base::error::EKError::InvalidInput("Failed to set RDMA request queue".into())
-        })?;
-    RDMA_RESP_QUEUE
-        .set(resp_queue_arc.clone())
-        .map_err(|_| {
-            ek_base::error::EKError::InvalidInput("Failed to set RDMA response queue".into())
-        })?;
+    RDMA_REQ_QUEUE.set(req_queue_arc.clone()).map_err(|_| {
+        ek_base::error::EKError::InvalidInput("Failed to set RDMA request queue".into())
+    })?;
+    RDMA_RESP_QUEUE.set(resp_queue_arc.clone()).map_err(|_| {
+        ek_base::error::EKError::InvalidInput("Failed to set RDMA response queue".into())
+    })?;
 
     // Create TCP server for endpoint exchange
     let endpoint_server = RdmaEndpointServer::new(req_queue_arc, resp_queue_arc)
         .map_err(|e| ek_base::error::EKError::IoError(e))?;
     let tcp_port = endpoint_server.port();
-    
+
     // Store TCP port globally
     RDMA_TCP_PORT
         .set(tcp_port)
-        .map_err(|_| {
-            ek_base::error::EKError::InvalidInput("Failed to set RDMA TCP port".into())
-        })?;
+        .map_err(|_| ek_base::error::EKError::InvalidInput("Failed to set RDMA TCP port".into()))?;
 
     // Start the TCP server and return its handle
     let endpoint_server_handle = tokio::spawn(async move {
@@ -102,8 +96,6 @@ async fn create_rdma_queues_with_tcp_server() -> EKResult<(u16, tokio::task::Joi
         }
     });
 
-    log::info!("🌐 RDMA TCP endpoint exchange server started on port {}", tcp_port);
-    
     Ok((tcp_port, endpoint_server_handle))
 }
 use crate::proto::ek::worker::v1::computation_service_server::ComputationServiceServer;
@@ -126,7 +118,10 @@ pub async fn worker_main() -> EKResult<()> {
 
     // Determine queue type based on configuration
     // Note: Channel should be created before stateClient start for endpoint exchange
-    let (rdma_tcp_port, endpoint_server_handle): (Option<u16>, Option<tokio::task::JoinHandle<()>>) = if settings.worker.channel == "rdma" {
+    let (rdma_tcp_port, endpoint_server_handle): (
+        Option<u16>,
+        Option<tokio::task::JoinHandle<()>>,
+    ) = if settings.worker.channel == "rdma" {
         match create_rdma_queues_with_tcp_server().await {
             Ok((tcp_port, handle)) => {
                 log::info!("RDMA queues and TCP server created successfully");
@@ -376,7 +371,7 @@ pub async fn worker_main() -> EKResult<()> {
             log::info!("ctrl-c signal received, shutting down");
             *poison.lock().unwrap() = true;
             token.clone().cancel();
-            
+
             // Wait for RDMA endpoint server to complete if it exists
             if let Some(handle) = endpoint_server_handle {
                 log::info!("Waiting for RDMA endpoint server to complete...");
@@ -384,7 +379,7 @@ pub async fn worker_main() -> EKResult<()> {
                     log::error!("RDMA endpoint server task failed: {}", e);
                 }
             }
-            
+
             let(_,rx) = get_graceful_shutdown_ch();
             rx.lock().await.recv().await;
             for srv in sync_srvs {

--- a/ek-computation/src/worker/state.rs
+++ b/ek-computation/src/worker/state.rs
@@ -27,6 +27,7 @@ use super::{
     core::get_instance_gate,
     manager::{ExpertDB, get_expert_db},
     x::{self},
+    {close_rdma_queues, is_rdma_queue_connected},
 };
 
 pub struct StateClient {
@@ -90,7 +91,7 @@ impl StateClient {
             },
             device: settings.worker.device.clone(),
             last_will: false,
-            rdma_tcp_port: rdma_tcp_port.map(|p| p as u32).unwrap_or(0)
+            rdma_tcp_port: rdma_tcp_port.map(|p| p as u32).unwrap_or(0),
         })
     }
 
@@ -141,6 +142,13 @@ impl StateClient {
             select! {
                 e = self.run_inner(token.clone()) => {
                     if let Err(e) = e {
+                        // If Rdma backend, clean status
+                        if self.rdma_tcp_port.is_some() && is_rdma_queue_connected() {
+                            log::info!("🚀 rdma connection lost, resetting rdma queues");
+                            close_rdma_queues();
+                            log::info!("🚀 rdma queues reset complete");
+                        }
+
                         log::error!("state client error {e:?}");
                         tokio::time::sleep(std::time::Duration::from_secs(3)).await;
                     }

--- a/ek-computation/src/worker/state.rs
+++ b/ek-computation/src/worker/state.rs
@@ -27,7 +27,6 @@ use super::{
     core::get_instance_gate,
     manager::{ExpertDB, get_expert_db},
     x::{self},
-    {is_rdma_queue_connected, update_rdma_connection_status},
 };
 
 pub struct StateClient {
@@ -36,7 +35,7 @@ pub struct StateClient {
     worker_id: String,
     gate_async: &'static EKInstanceGateAsync, // Use async gate for state management
     controller_addr: Endpoint,
-    rdma_endpoints: Option<crate::proto::ek::worker::v1::RdmaEndpointPair>,
+    rdma_tcp_port: Option<u16>,
 }
 
 impl StateClient {
@@ -50,14 +49,14 @@ impl StateClient {
             worker_id: worker_id.to_owned(),
             gate_async,
             controller_addr: addr,
-            rdma_endpoints: None,
+            rdma_tcp_port: None,
         }
     }
 
-    pub fn new_with_rdma(
+    pub fn new_with_rdma_tcp_port(
         addr: Endpoint,
         worker_id: &str,
-        rdma_endpoints: Option<crate::proto::ek::worker::v1::RdmaEndpointPair>,
+        rdma_tcp_port: Option<u16>,
     ) -> Self {
         let edb = get_expert_db();
         let gate_async = get_instance_gate();
@@ -68,14 +67,14 @@ impl StateClient {
             worker_id: worker_id.to_owned(),
             gate_async,
             controller_addr: addr,
-            rdma_endpoints,
+            rdma_tcp_port,
         }
     }
 
     /// Generate request stream for state exchange
     fn get_request_stream(
         worker_id: String,
-        rdma_endpoints: Option<crate::proto::ek::worker::v1::RdmaEndpointPair>,
+        rdma_tcp_port: Option<u16>,
     ) -> impl Stream<Item = ExchangeReq> {
         let settings = get_ek_settings();
         tokio_stream::iter(1..usize::MAX).map(move |_| ExchangeReq {
@@ -84,14 +83,14 @@ impl StateClient {
                 "http://{}:{}",
                 settings.worker.broadcast, settings.worker.ports.main
             ),
-            channel: if rdma_endpoints.is_some() {
+            channel: if rdma_tcp_port.is_some() {
                 "rdma".to_string()
             } else {
                 settings.worker.channel.clone()
             },
             device: settings.worker.device.clone(),
             last_will: false,
-            rdma_endpoints: rdma_endpoints.clone(),
+            rdma_tcp_port: rdma_tcp_port.map(|p| p as u32).unwrap_or(0)
         })
     }
 
@@ -110,142 +109,15 @@ impl StateClient {
                     }
                 }
             }
-            // Handle controller RDMA endpoints for bidirectional connection
-            if let Some(controller_rdma_endpoints) = msg.rdma_endpoints {
-                if is_rdma_queue_connected() {
-                    log::debug!("Rdma connection already established, skip connect logic")
-                } else {
-                    log::info!("Received controller RDMA endpoints, establishing connection...");
-                    if let Err(e) = self
-                        .handle_controller_rdma_endpoints(controller_rdma_endpoints)
-                        .await
-                    {
-                        log::error!("Failed to establish RDMA connection with controller: {e:?}");
-                    }
-                }
-            }
         }
-        Ok(())
-    }
-
-    /// Handle controller RDMA endpoints and establish bidirectional connection
-    async fn handle_controller_rdma_endpoints(
-        &mut self,
-        controller_endpoints: crate::proto::ek::worker::v1::RdmaEndpointPair,
-    ) -> EKResult<()> {
-        // Get RDMA queues from global storage
-        let _req_queue = crate::worker::get_rdma_req_queue().ok_or_else(|| {
-            ek_base::error::EKError::NotFound("Worker RDMA request queue not found".into())
-        })?;
-        let _resp_queue = crate::worker::get_rdma_resp_queue().ok_or_else(|| {
-            ek_base::error::EKError::NotFound("Worker RDMA response queue not found".into())
-        })?;
-
-        // Extract controller endpoints
-        let controller_req_endpoint = controller_endpoints.request_endpoint.ok_or_else(|| {
-            ek_base::error::EKError::InvalidInput("Missing controller request endpoint".into())
-        })?;
-
-        let controller_resp_endpoint = controller_endpoints.response_endpoint.ok_or_else(|| {
-            ek_base::error::EKError::InvalidInput("Missing controller response endpoint".into())
-        })?;
-
-        // Deserialize controller request endpoint (where worker receives requests)
-        let controller_req_qp_endpoint: ibverbs::QueuePairEndpoint =
-            serde_json::from_str(&controller_req_endpoint.qp_endpoint).map_err(|e| {
-                ek_base::error::EKError::InvalidInput(format!(
-                    "Failed to deserialize controller request QP endpoint: {e}"
-                ))
-            })?;
-
-        let controller_req_memory_region: ibverbs::RemoteMemoryRegion =
-            serde_json::from_str(&controller_req_endpoint.memory_region).map_err(|e| {
-                ek_base::error::EKError::InvalidInput(format!(
-                    "Failed to deserialize controller request memory region: {e}"
-                ))
-            })?;
-
-        // Deserialize controller response endpoint (where worker sends responses)
-        let controller_resp_qp_endpoint: ibverbs::QueuePairEndpoint =
-            serde_json::from_str(&controller_resp_endpoint.qp_endpoint).map_err(|e| {
-                ek_base::error::EKError::InvalidInput(format!(
-                    "Failed to deserialize controller response QP endpoint: {e}"
-                ))
-            })?;
-
-        let controller_resp_memory_region: ibverbs::RemoteMemoryRegion =
-            serde_json::from_str(&controller_resp_endpoint.memory_region).map_err(|e| {
-                ek_base::error::EKError::InvalidInput(format!(
-                    "Failed to deserialize controller response memory region: {e}"
-                ))
-            })?;
-
-        log::info!("Establishing RDMA connection with controller");
-        log::info!(
-            "Controller request QP endpoint: {:?}",
-            controller_req_qp_endpoint
-        );
-        log::info!(
-            "Controller request memory region: {:?}",
-            controller_req_memory_region
-        );
-        log::info!(
-            "Controller response QP endpoint: {:?}",
-            controller_resp_qp_endpoint
-        );
-        log::info!(
-            "Controller response memory region: {:?}",
-            controller_resp_memory_region
-        );
-
-        // Connect worker's request queue to controller's request queue (for receiving requests)
-        {
-            let mut req_queue_lock = _req_queue.lock().unwrap();
-            if req_queue_lock.is_connected() {
-                log::info!("Worker request queue already connected to controller, skipping");
-            } else {
-                if let Err(e) = req_queue_lock.connect(
-                    controller_req_qp_endpoint,
-                    controller_req_memory_region.clone(),
-                ) {
-                    log::error!("Failed to connect worker request queue to controller: {e}");
-                    return Err(ek_base::error::EKError::IoError(std::io::Error::other(
-                        format!("RDMA request queue connection failed: {e}"),
-                    )));
-                }
-                log::info!("🚀Worker request queue connected to controller successfully");
-            }
-        }
-
-        // Connect worker's response queue to controller's response queue (for sending responses)
-        {
-            let mut resp_queue_lock = _resp_queue.lock().unwrap();
-            if resp_queue_lock.is_connected() {
-                log::info!("Worker response queue already connected to controller, skipping");
-            } else {
-                if let Err(e) = resp_queue_lock
-                    .connect(controller_resp_qp_endpoint, controller_resp_memory_region)
-                {
-                    log::error!("Failed to connect worker response queue to controller: {e}");
-                    return Err(ek_base::error::EKError::IoError(std::io::Error::other(
-                        format!("RDMA response queue connection failed: {e}"),
-                    )));
-                }
-                log::info!("🚀Worker response queue connected to controller successfully");
-            }
-        }
-
-        update_rdma_connection_status(true);
-        log::info!("🚀RDMA bidirectional connection established successfully");
         Ok(())
     }
 
     /// Inner run loop for state client
     async fn run_inner(&mut self, token: CancellationToken) -> EKResult<()> {
         let mut cli = StateServiceClient::connect(self.controller_addr.clone()).await?;
-        let req_stream =
-            Self::get_request_stream(self.worker_id.clone(), self.rdma_endpoints.clone())
-                .throttle(std::time::Duration::from_secs(3));
+        let req_stream = Self::get_request_stream(self.worker_id.clone(), self.rdma_tcp_port)
+            .throttle(std::time::Duration::from_secs(3));
         let res = cli.exchange(req_stream).await?;
         let mut stream = res.into_inner();
         loop {

--- a/ek-proto/ek/worker/v1/expert.proto
+++ b/ek-proto/ek/worker/v1/expert.proto
@@ -31,29 +31,18 @@ message ExpertState {
   Stage stage = 1;
 }
 
-message RdmaEndpoint {
-  string qp_endpoint = 1;   // JSON-serialized QueuePairEndpoint
-  string memory_region = 2; // JSON-serialized RemoteMemoryRegion
-}
-
-message RdmaEndpointPair {
-  RdmaEndpoint request_endpoint = 1;  // For request queue
-  RdmaEndpoint response_endpoint = 2; // For response queue
-}
-
 message ExchangeReq {
   string id = 1;
   string addr = 2;
   string channel = 3;
   string device = 4;
   bool last_will = 5;
-  RdmaEndpointPair rdma_endpoints = 6;
+  uint32 rdma_tcp_port = 6;
 }
 
 message ExchangeResp {
   message ExpertWithState { ek.object.v1.ExpertSlice target = 1; }
   ExpertWithState state = 1;
-  RdmaEndpointPair rdma_endpoints = 2;
 }
 
 service StateService {


### PR DESCRIPTION
Previous Rdma connection use state server for endpoint info exchange, and use database to exchange the info between controller components (Registry and StateServer). Which cause unstable rdma connection procedure(e.g. connect failed and use hardcode sleep to guarantee the establishment).
This PR improve this and make changes below:
1. Make a simple TCP connection for endpoint info exchange
2. The Connection use lazy connection, which means connect when expert calculation requests comes
3. The RdmaEndpointServer will released once connection built, and release cpu occupation
4. Remove complexed endpoint info serialization process
5. Fix serveral bugs