### PR TITLE
Add frontend transport tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,6 +1495,7 @@ dependencies = [
  "ndarray",
  "ndarray-rand",
  "nix 0.30.1",
+ "opentelemetry",
  "ort",
  "ort-sys",
  "prometheus",
@@ -1630,6 +1631,10 @@ dependencies = [
  "log",
  "ndarray",
  "nix 0.29.0",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
  "parking_lot",
  "prost 0.12.6",
  "pyo3",
@@ -1644,6 +1649,9 @@ dependencies = [
  "tonic 0.11.0",
  "tonic-build 0.11.0",
  "tower 0.4.13",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/ek-computation/Cargo.toml
+++ b/ek-computation/Cargo.toml
@@ -45,6 +45,7 @@ tonic = { workspace = true }
 tower = { workspace = true }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
+opentelemetry = { workspace = true }
 url = { workspace = true }
 
 [build-dependencies]

--- a/ek-computation/src/lib.rs
+++ b/ek-computation/src/lib.rs
@@ -2,6 +2,7 @@ pub mod backend;
 pub mod controller;
 pub mod ffn;
 pub mod metrics;
+pub mod observability;
 pub mod onnx;
 pub mod proto;
 mod schema;

--- a/ek-computation/src/observability.rs
+++ b/ek-computation/src/observability.rs
@@ -1,0 +1,203 @@
+use std::{
+    collections::HashMap,
+    sync::atomic::{AtomicU64, Ordering},
+    time::Instant,
+};
+
+use opentelemetry::propagation::{Extractor, Injector};
+use tonic::metadata::MetadataMap;
+use tracing::{Level, Span};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+static REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+static EXPERT_CALL_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Clone)]
+pub struct TraceLabels {
+    pub component: &'static str,
+    pub stage: &'static str,
+    pub path: &'static str,
+    pub request_id: u64,
+    pub layer_id: u64,
+    pub expert_call_id: u64,
+    pub expert_id: String,
+    pub worker: String,
+    pub num_tokens: usize,
+}
+
+impl TraceLabels {
+    pub fn new(component: &'static str, stage: &'static str) -> Self {
+        Self {
+            component,
+            stage,
+            path: "unknown",
+            request_id: 0,
+            layer_id: 0,
+            expert_call_id: 0,
+            expert_id: String::new(),
+            worker: String::new(),
+            num_tokens: 0,
+        }
+    }
+
+    pub fn path(mut self, path: &'static str) -> Self {
+        self.path = path;
+        self
+    }
+
+    pub fn request_id(mut self, request_id: u64) -> Self {
+        self.request_id = request_id;
+        self
+    }
+
+    pub fn layer_id(mut self, layer_id: u64) -> Self {
+        self.layer_id = layer_id;
+        self
+    }
+
+    pub fn expert_call_id(mut self, expert_call_id: u64) -> Self {
+        self.expert_call_id = expert_call_id;
+        self
+    }
+
+    pub fn expert_id(mut self, expert_id: impl Into<String>) -> Self {
+        self.expert_id = expert_id.into();
+        self
+    }
+
+    pub fn worker(mut self, worker: impl Into<String>) -> Self {
+        self.worker = worker.into();
+        self
+    }
+
+    pub fn num_tokens(mut self, num_tokens: usize) -> Self {
+        self.num_tokens = num_tokens;
+        self
+    }
+}
+
+pub struct StageTimer {
+    labels: TraceLabels,
+    start: Instant,
+    span: Span,
+}
+
+impl StageTimer {
+    pub fn start(labels: TraceLabels) -> Self {
+        let span = trace_span(&labels);
+        Self::start_with_span(labels, span)
+    }
+
+    pub fn start_with_span(labels: TraceLabels, span: Span) -> Self {
+        Self {
+            labels,
+            start: Instant::now(),
+            span,
+        }
+    }
+
+    pub fn span(&self) -> Span {
+        self.span.clone()
+    }
+}
+
+impl Drop for StageTimer {
+    fn drop(&mut self) {
+        let elapsed_us = self.start.elapsed().as_micros() as u64;
+        let labels = &self.labels;
+        self.span.in_scope(|| {
+            tracing::info!(
+                elapsed_us,
+                component = labels.component,
+                stage = labels.stage,
+                path = labels.path,
+                request_id = labels.request_id,
+                layer_id = labels.layer_id,
+                expert_call_id = labels.expert_call_id,
+                expert_id = labels.expert_id.as_str(),
+                worker = labels.worker.as_str(),
+                num_tokens = labels.num_tokens,
+                "expert-kit trace stage done",
+            );
+        });
+    }
+}
+
+pub fn next_request_id() -> u64 {
+    REQUEST_ID.fetch_add(1, Ordering::SeqCst)
+}
+
+pub fn next_expert_call_id() -> u64 {
+    EXPERT_CALL_ID.fetch_add(1, Ordering::SeqCst)
+}
+
+pub fn trace_span(labels: &TraceLabels) -> Span {
+    tracing::span!(
+        Level::INFO,
+        "ek.trace",
+        otel.name = labels.stage,
+        component = labels.component,
+        stage = labels.stage,
+        path = labels.path,
+        request_id = labels.request_id,
+        layer_id = labels.layer_id,
+        expert_call_id = labels.expert_call_id,
+        expert_id = labels.expert_id.as_str(),
+        worker = labels.worker.as_str(),
+        num_tokens = labels.num_tokens,
+    )
+}
+
+pub fn child_span_from_traceparent(labels: &TraceLabels, traceparent: &str) -> Span {
+    let span = trace_span(labels);
+    if !traceparent.is_empty() {
+        let mut headers = HashMap::new();
+        headers.insert("traceparent".to_string(), traceparent.to_string());
+        let extractor = StringMapExtractor(headers);
+        let ctx = opentelemetry::global::get_text_map_propagator(|propagator| {
+            propagator.extract(&extractor)
+        });
+        span.set_parent(ctx);
+    }
+    span
+}
+
+pub fn extract_traceparent(metadata: &MetadataMap) -> String {
+    metadata
+        .get("traceparent")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_string()
+}
+
+pub fn inject_current_trace_context(metadata: &mut MetadataMap) {
+    let ctx = Span::current().context();
+    let mut injector = MetadataInjector(metadata);
+    opentelemetry::global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(&ctx, &mut injector);
+    });
+}
+
+struct MetadataInjector<'a>(&'a mut MetadataMap);
+
+impl Injector for MetadataInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        if let Ok(key) = tonic::metadata::MetadataKey::from_bytes(key.as_bytes())
+            && let Ok(value) = value.parse()
+        {
+            self.0.insert(key, value);
+        }
+    }
+}
+
+struct StringMapExtractor(HashMap<String, String>);
+
+impl Extractor for StringMapExtractor {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).map(String::as_str)
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(String::as_str).collect()
+    }
+}

--- a/ek-integration/expertkit-transport-rs/Cargo.toml
+++ b/ek-integration/expertkit-transport-rs/Cargo.toml
@@ -22,6 +22,13 @@ serde_json = "1.0"
 anyhow = "1.0"
 log = { workspace = true }
 env_logger = { workspace = true }
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true }
+opentelemetry-otlp = { workspace = true }
+opentelemetry-semantic-conventions = { workspace = true }
+tracing = { workspace = true }
+tracing-opentelemetry = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 # gRPC dependencies (Phase 2)
 tonic = "0.11"

--- a/ek-integration/expertkit-transport-rs/src/client.rs
+++ b/ek-integration/expertkit-transport-rs/src/client.rs
@@ -4,15 +4,71 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tonic::transport::Channel;
+use tracing::{Instrument, Span};
 
-use crate::routing::RoutingClient;
-use crate::transport::{ExpertRequest, Transport, auto::AutoTransport};
-use crate::transport::grpc::proto::ek::worker::v1::{
-    ForwardReq, forward_req::SequenceInfo, computation_service_client::ComputationServiceClient,
+use crate::observability::{
+    StageTimer, TraceLabels, infer_layer_id, inject_current_trace_context, next_expert_call_id,
+    next_layer_id, next_request_id,
 };
+use crate::routing::RoutingClient;
+use crate::transport::grpc::proto::ek::worker::v1::{
+    ForwardReq, computation_service_client::ComputationServiceClient, forward_req::SequenceInfo,
+};
+use crate::transport::{ExpertRequest, Transport, auto::AutoTransport};
 use crate::utils::{deserialize_safetensor_2_tch_tensor, serialize_tch_tensor_2_safetensor};
 
 use tch::Tensor;
+
+struct ForwardTrace {
+    request_id: u64,
+    layer_id: u64,
+    layer_span: Span,
+    _request_timer: StageTimer,
+    _layer_timer: StageTimer,
+}
+
+impl ForwardTrace {
+    fn start(
+        expert_ids: &[Vec<String>],
+        batch_size: usize,
+        hidden_dim: usize,
+        path: &'static str,
+    ) -> Self {
+        let request_id = next_request_id();
+        let inferred_layer_id = infer_layer_id(expert_ids, next_layer_id());
+        let request_timer = StageTimer::start(
+            TraceLabels::new("frontend", "frontend.request")
+                .path(path)
+                .request_id(request_id)
+                .layer_id(inferred_layer_id)
+                .num_tokens(batch_size),
+        );
+        let request_span = request_timer.span();
+        let layer_timer = {
+            let _entered = request_span.enter();
+            StageTimer::start(
+                TraceLabels::new("frontend", "frontend.layer")
+                    .path(path)
+                    .request_id(request_id)
+                    .layer_id(inferred_layer_id)
+                    .num_tokens(batch_size),
+            )
+        };
+        let _ = hidden_dim;
+        Self {
+            request_id,
+            layer_id: inferred_layer_id,
+            layer_span: layer_timer.span(),
+            _request_timer: request_timer,
+            _layer_timer: layer_timer,
+        }
+    }
+
+    fn child_timer(&self, labels: TraceLabels) -> StageTimer {
+        let _entered = self.layer_span.enter();
+        StageTimer::start(labels.request_id(self.request_id).layer_id(self.layer_id))
+    }
+}
 
 /// Result of a single expert task execution
 enum ExpertTaskResult {
@@ -54,7 +110,9 @@ impl ExpertKitClient {
         routing.fetch_routing(None).await?;
 
         // Establish controller channel for fallback requests
-        let uri = if self.controller_addr.starts_with("http://") || self.controller_addr.starts_with("https://") {
+        let uri = if self.controller_addr.starts_with("http://")
+            || self.controller_addr.starts_with("https://")
+        {
             self.controller_addr.clone()
         } else {
             format!("http://{}", self.controller_addr)
@@ -86,6 +144,9 @@ impl ExpertKitClient {
         routing: Arc<RoutingClient>,
         pre_assigned_worker: crate::transport::grpc::proto::ek::control::v1::WorkerEndpoint,
         task_create_t: std::time::Instant,
+        request_id: u64,
+        layer_id: u64,
+        expert_call_id: u64,
     ) -> ExpertTaskResult {
         let sub_task_t = std::time::Instant::now();
 
@@ -107,19 +168,51 @@ impl ExpertKitClient {
             .collect();
 
         // Create index tensor and slice
-        let index_tensor = Tensor::from_slice(&seq_indices);
-        let expert_input = hidden_state.index_select(0, &index_tensor);
+        let expert_input = {
+            let timer = StageTimer::start(
+                TraceLabels::new("frontend", "frontend.tensor_slice")
+                    .path("direct_worker")
+                    .request_id(request_id)
+                    .layer_id(layer_id)
+                    .expert_call_id(expert_call_id)
+                    .expert_id(expert_id.as_str())
+                    .worker(worker_endpoint.grpc_addr.as_str())
+                    .num_tokens(seq_indices.len()),
+            );
+            let span = timer.span();
+            let _entered = span.enter();
+            let index_tensor = Tensor::from_slice(&seq_indices);
+            let tensor = hidden_state.index_select(0, &index_tensor);
+            drop(timer);
+            tensor
+        };
 
         // Serialize for network transfer
-        let tensor_bytes = match serialize_tch_tensor_2_safetensor(&expert_input) {
-            Ok(bytes) => bytes,
-            Err(e) => {
-                return ExpertTaskResult::Failed(
-                    expert_id,
-                    format!("Failed to serialize tensor: {}", e),
-                    Some(worker_endpoint.grpc_addr.clone()),
-                );
-            }
+        let tensor_bytes = {
+            let timer = StageTimer::start(
+                TraceLabels::new("frontend", "frontend.serialize")
+                    .path("direct_worker")
+                    .request_id(request_id)
+                    .layer_id(layer_id)
+                    .expert_call_id(expert_call_id)
+                    .expert_id(expert_id.as_str())
+                    .worker(worker_endpoint.grpc_addr.as_str())
+                    .num_tokens(seq_indices.len()),
+            );
+            let span = timer.span();
+            let _entered = span.enter();
+            let result = match serialize_tch_tensor_2_safetensor(&expert_input) {
+                Ok(bytes) => bytes,
+                Err(e) => {
+                    return ExpertTaskResult::Failed(
+                        expert_id,
+                        format!("Failed to serialize tensor: {}", e),
+                        Some(worker_endpoint.grpc_addr.clone()),
+                    );
+                }
+            };
+            drop(timer);
+            result
         };
         let num_sequences = seq_indices.len();
 
@@ -133,23 +226,52 @@ impl ExpertKitClient {
         );
 
         // Create request
-        let request = ExpertRequest::new(expert_id.clone(), tensor_bytes, num_sequences);
+        let request = ExpertRequest::new(expert_id.clone(), tensor_bytes, num_sequences)
+            .with_trace_context(request_id, layer_id, expert_call_id);
 
         let send_t = std::time::Instant::now();
+        let send_timer = StageTimer::start(
+            TraceLabels::new("frontend", "frontend.send_worker")
+                .path("direct_worker")
+                .request_id(request_id)
+                .layer_id(layer_id)
+                .expert_call_id(expert_call_id)
+                .expert_id(expert_id.as_str())
+                .worker(worker_endpoint.grpc_addr.as_str())
+                .num_tokens(num_sequences),
+        );
+        let send_span = send_timer.span();
         let result = transport
             .send_batch(&worker_endpoint, vec![request])
+            .instrument(send_span)
             .await;
+        drop(send_timer);
         let rtt_ms = send_t.elapsed().as_secs_f64() * 1000.0;
 
         // Track request completion (decrement inflight, update RTT and throughput)
-        routing.on_request_complete(&worker_endpoint, rtt_ms, num_sequences).await;
+        routing
+            .on_request_complete(&worker_endpoint, rtt_ms, num_sequences)
+            .await;
 
         let addr = worker_endpoint.grpc_addr.clone();
         match result {
             Ok(responses) => {
                 if let Some(response) = responses.into_iter().next() {
+                    let timer = StageTimer::start(
+                        TraceLabels::new("frontend", "frontend.deserialize")
+                            .path("direct_worker")
+                            .request_id(request_id)
+                            .layer_id(layer_id)
+                            .expert_call_id(expert_call_id)
+                            .expert_id(expert_id.as_str())
+                            .worker(addr.as_str())
+                            .num_tokens(num_sequences),
+                    );
+                    let span = timer.span();
+                    let _entered = span.enter();
                     match deserialize_safetensor_2_tch_tensor(&response.tensor_data) {
                         Ok(tensor) => {
+                            drop(timer);
                             debug!(
                                 "[Client-Time] 🔚 Sub-task for expert {} on worker {} completed in {:?} μs, send_batch took {:?} μs (RTT={:.2}ms), cost from task create time {:?} μs",
                                 expert_id,
@@ -161,14 +283,21 @@ impl ExpertKitClient {
                             );
                             ExpertTaskResult::Success(expert_id, tensor)
                         }
-                        Err(e) => ExpertTaskResult::Failed(
-                            expert_id,
-                            format!("Failed to deserialize response: {}", e),
-                            Some(addr),
-                        ),
+                        Err(e) => {
+                            drop(timer);
+                            ExpertTaskResult::Failed(
+                                expert_id,
+                                format!("Failed to deserialize response: {}", e),
+                                Some(addr),
+                            )
+                        }
                     }
                 } else {
-                    ExpertTaskResult::Failed(expert_id, "Empty response from worker".to_string(), Some(addr))
+                    ExpertTaskResult::Failed(
+                        expert_id,
+                        "Empty response from worker".to_string(),
+                        Some(addr),
+                    )
                 }
             }
             Err(e) => {
@@ -176,7 +305,11 @@ impl ExpertKitClient {
                     "[Client] Expert {} failed on worker {}: {}",
                     expert_id, addr, e
                 );
-                ExpertTaskResult::Failed(expert_id, format!("Worker request failed: {}", e), Some(addr))
+                ExpertTaskResult::Failed(
+                    expert_id,
+                    format!("Worker request failed: {}", e),
+                    Some(addr),
+                )
             }
         }
     }
@@ -190,6 +323,19 @@ impl ExpertKitClient {
     ) -> Result<Tensor> {
         let batch_size = hidden_state.size()[0] as usize;
         let hidden_dim = hidden_state.size()[1] as usize;
+        let trace = ForwardTrace::start(&expert_ids, batch_size, hidden_dim, "direct_worker");
+        self.forward_expert_tensor_direct(expert_ids, hidden_state, &trace)
+            .await
+    }
+
+    async fn forward_expert_tensor_direct(
+        &self,
+        expert_ids: Vec<Vec<String>>,
+        hidden_state: Tensor,
+        trace: &ForwardTrace,
+    ) -> Result<Tensor> {
+        let batch_size = hidden_state.size()[0] as usize;
+        let hidden_dim = hidden_state.size()[1] as usize;
 
         debug!(
             "[Client] forward_expert_tensor: batch_size={}, hidden_dim={}, device={:?}",
@@ -199,16 +345,26 @@ impl ExpertKitClient {
         );
 
         // Decompose by expert
-        let mut expert_to_sequences: HashMap<String, Vec<(usize, usize)>> = HashMap::new();
-
-        for (seq_idx, experts) in expert_ids.iter().enumerate() {
-            for (expert_idx, expert_id) in experts.iter().enumerate() {
-                expert_to_sequences
-                    .entry(expert_id.clone())
-                    .or_default()
-                    .push((seq_idx, expert_idx));
+        let expert_to_sequences: HashMap<String, Vec<(usize, usize)>> = {
+            let timer = trace.child_timer(
+                TraceLabels::new("frontend", "frontend.decompose")
+                    .path("direct_worker")
+                    .num_tokens(expert_ids.len()),
+            );
+            let span = timer.span();
+            let _entered = span.enter();
+            let mut expert_to_sequences: HashMap<String, Vec<(usize, usize)>> = HashMap::new();
+            for (seq_idx, experts) in expert_ids.iter().enumerate() {
+                for (expert_idx, expert_id) in experts.iter().enumerate() {
+                    expert_to_sequences
+                        .entry(expert_id.clone())
+                        .or_default()
+                        .push((seq_idx, expert_idx));
+                }
             }
-        }
+            drop(timer);
+            expert_to_sequences
+        };
 
         info!(
             "[Client] Decomposed {} sequences into {} unique experts",
@@ -250,7 +406,18 @@ impl ExpertKitClient {
             .iter()
             .map(|(eid, positions)| (eid.clone(), positions.len()))
             .collect();
-        let mut assignments = self.routing.assign_layer_batch(&expert_calls).await;
+        let routing_timer = trace.child_timer(
+            TraceLabels::new("frontend", "frontend.route")
+                .path("direct_worker")
+                .num_tokens(expert_calls.len()),
+        );
+        let routing_span = routing_timer.span();
+        let mut assignments = self
+            .routing
+            .assign_layer_batch(&expert_calls)
+            .instrument(routing_span)
+            .await;
+        drop(routing_timer);
 
         // Build requests: slice tensor directly and spawn tasks immediately
         let mut jobs: tokio::task::JoinSet<ExpertTaskResult> = tokio::task::JoinSet::new();
@@ -267,13 +434,24 @@ impl ExpertKitClient {
             let worker = match assignments.remove(expert_id) {
                 Some(w) => w,
                 None => {
-                    warn!("[Client] Expert {} missing from LPT assignment, falling back to dynamic selection", expert_id);
-                    match self.routing.select_worker_and_mark_inflight(expert_id).await {
+                    warn!(
+                        "[Client] Expert {} missing from LPT assignment, falling back to dynamic selection",
+                        expert_id
+                    );
+                    match self
+                        .routing
+                        .select_worker_and_mark_inflight(expert_id)
+                        .await
+                    {
                         Some(w) => w,
                         None => {
                             let eid = expert_id.clone();
                             jobs.spawn(async move {
-                                ExpertTaskResult::Failed(eid, "No worker available".to_string(), None)
+                                ExpertTaskResult::Failed(
+                                    eid,
+                                    "No worker available".to_string(),
+                                    None,
+                                )
                             });
                             continue;
                         }
@@ -286,8 +464,26 @@ impl ExpertKitClient {
             let seq_positions_clone = seq_positions.clone();
             let transport = self.transport.clone();
             let routing = self.routing.clone();
+            let request_id = trace.request_id;
+            let layer_id = trace.layer_id;
+            let expert_call_id = next_expert_call_id();
+            let expert_timer = {
+                let _entered = trace.layer_span.enter();
+                StageTimer::start(
+                    TraceLabels::new("frontend", "frontend.expert_call")
+                        .path("direct_worker")
+                        .request_id(request_id)
+                        .layer_id(layer_id)
+                        .expert_call_id(expert_call_id)
+                        .expert_id(expert_id.as_str())
+                        .worker(worker.grpc_addr.as_str())
+                        .num_tokens(seq_positions.len()),
+                )
+            };
+            let expert_span = expert_timer.span();
 
             jobs.spawn(async move {
+                let _expert_timer = expert_timer;
                 Self::execute_expert_task(
                     expert_id_clone,
                     seq_positions_clone,
@@ -296,7 +492,11 @@ impl ExpertKitClient {
                     routing,
                     worker,
                     task_create_t,
+                    request_id,
+                    layer_id,
+                    expert_call_id,
                 )
+                .instrument(expert_span)
                 .await
             });
         }
@@ -339,10 +539,7 @@ impl ExpertKitClient {
         // a worker loads the expert.  Retrying on the frontend is wasteful
         // because it re-selects from a potentially stale routing table.
         if !failed_experts.is_empty() {
-            let failed_ids: Vec<String> = failed_experts
-                .into_iter()
-                .map(|(id, _)| id)
-                .collect();
+            let failed_ids: Vec<String> = failed_experts.into_iter().map(|(id, _)| id).collect();
             warn!(
                 "[Client] {} expert tasks failed on direct path, deferring to controller fallback: {:?}",
                 failed_ids.len(),
@@ -376,6 +573,13 @@ impl ExpertKitClient {
         );
 
         let t = std::time::Instant::now();
+        let merge_timer = trace.child_timer(
+            TraceLabels::new("frontend", "frontend.merge")
+                .path("direct_worker")
+                .num_tokens(batch_size),
+        );
+        let merge_span = merge_timer.span();
+        let _merge_entered = merge_span.enter();
         for (expert_id_resp, resp_tensor) in successful_results.iter() {
             let seq_positions = expert_metadata
                 .get(expert_id_resp)
@@ -420,6 +624,7 @@ impl ExpertKitClient {
             "[Client-Time] 🧩 Completed stacking of final output tensors in {:?} μs",
             t.elapsed().as_micros()
         );
+        drop(merge_timer);
 
         Ok(final_output)
     }
@@ -466,12 +671,24 @@ impl ExpertKitClient {
         &self,
         expert_ids: &[Vec<String>],
         hidden_state: &Tensor,
+        trace: &ForwardTrace,
     ) -> Result<Tensor> {
-        let channel = self.controller_channel.as_ref()
+        let channel = self
+            .controller_channel
+            .as_ref()
             .ok_or_else(|| anyhow::anyhow!("Controller channel not established"))?;
 
         // Serialize the hidden state tensor
-        let tensor_bytes = serialize_tch_tensor_2_safetensor(hidden_state)?;
+        let serialize_timer = trace.child_timer(
+            TraceLabels::new("frontend", "frontend.serialize")
+                .path("fallback_controller")
+                .num_tokens(expert_ids.len()),
+        );
+        let serialize_span = serialize_timer.span();
+        let tensor_bytes = async { serialize_tch_tensor_2_safetensor(hidden_state) }
+            .instrument(serialize_span)
+            .await?;
+        drop(serialize_timer);
 
         // Build sequences info for the request
         let sequences: Vec<SequenceInfo> = expert_ids
@@ -499,13 +716,37 @@ impl ExpertKitClient {
             .max_encoding_message_size(max_message_size);
 
         // Send with timeout
-        let response = tokio::time::timeout(self.timeout, client.forward(req))
-            .await
-            .map_err(|_| anyhow::anyhow!("Controller fallback timeout after {:?}", self.timeout))?
-            .map_err(|e| anyhow::anyhow!("Controller fallback gRPC error: {}", e))?;
+        let send_timer = trace.child_timer(
+            TraceLabels::new("frontend", "frontend.send_controller")
+                .path("fallback_controller")
+                .num_tokens(expert_ids.len()),
+        );
+        let send_span = send_timer.span();
+        let response = tokio::time::timeout(
+            self.timeout,
+            async {
+                let mut req = tonic::Request::new(req);
+                inject_current_trace_context(req.metadata_mut());
+                client.forward(req).await
+            }
+            .instrument(send_span),
+        )
+        .await
+        .map_err(|_| anyhow::anyhow!("Controller fallback timeout after {:?}", self.timeout))?
+        .map_err(|e| anyhow::anyhow!("Controller fallback gRPC error: {}", e))?;
+        drop(send_timer);
 
         let output_tensor = response.into_inner().output_tensor;
-        let result = deserialize_safetensor_2_tch_tensor(&output_tensor)?;
+        let deserialize_timer = trace.child_timer(
+            TraceLabels::new("frontend", "frontend.deserialize")
+                .path("fallback_controller")
+                .num_tokens(expert_ids.len()),
+        );
+        let deserialize_span = deserialize_timer.span();
+        let result = async { deserialize_safetensor_2_tch_tensor(&output_tensor) }
+            .instrument(deserialize_span)
+            .await?;
+        drop(deserialize_timer);
 
         info!("[Client] Controller fallback completed successfully");
 
@@ -519,8 +760,14 @@ impl ExpertKitClient {
         expert_ids: Vec<Vec<String>>,
         hidden_state: Tensor,
     ) -> Result<Tensor> {
+        let batch_size = hidden_state.size()[0] as usize;
+        let hidden_dim = hidden_state.size()[1] as usize;
+        let trace = ForwardTrace::start(&expert_ids, batch_size, hidden_dim, "direct_or_fallback");
         // Try direct worker path first (it already has retry logic)
-        match self.forward_expert_tensor(expert_ids.clone(), hidden_state.shallow_clone()).await {
+        match self
+            .forward_expert_tensor_direct(expert_ids.clone(), hidden_state.shallow_clone(), &trace)
+            .await
+        {
             Ok(result) => Ok(result),
             Err(e) => {
                 warn!(
@@ -537,16 +784,16 @@ impl ExpertKitClient {
                 }
 
                 // Fallback to controller as last resort
-                match self.forward_via_controller(&expert_ids, &hidden_state).await {
+                match self
+                    .forward_via_controller(&expert_ids, &hidden_state, &trace)
+                    .await
+                {
                     Ok(result) => {
                         info!("[Client] Controller fallback succeeded");
                         Ok(result)
                     }
                     Err(fallback_err) => {
-                        error!(
-                            "[Client] Controller fallback also failed: {}",
-                            fallback_err
-                        );
+                        error!("[Client] Controller fallback also failed: {}", fallback_err);
                         Err(anyhow::anyhow!(
                             "All paths failed. Direct: {}. Controller: {}",
                             e,

--- a/ek-integration/expertkit-transport-rs/src/lib.rs
+++ b/ek-integration/expertkit-transport-rs/src/lib.rs
@@ -6,6 +6,7 @@ use pyo3::prelude::*;
 
 mod client;
 mod lb;
+mod observability;
 mod python;
 mod routing;
 mod transport;

--- a/ek-integration/expertkit-transport-rs/src/observability.rs
+++ b/ek-integration/expertkit-transport-rs/src/observability.rs
@@ -1,0 +1,248 @@
+use std::{
+    sync::{
+        Once,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Instant,
+};
+
+use opentelemetry::propagation::Injector;
+use opentelemetry::{
+    KeyValue, propagation::TextMapCompositePropagator, trace::TracerProvider as _,
+};
+use opentelemetry_sdk::{
+    Resource,
+    propagation::{BaggagePropagator, TraceContextPropagator},
+    trace::{RandomIdGenerator, Sampler, SdkTracerProvider},
+};
+use opentelemetry_semantic_conventions::{
+    SCHEMA_URL,
+    resource::{DEPLOYMENT_ENVIRONMENT_NAME, SERVICE_VERSION},
+};
+use tonic::metadata::MetadataMap;
+use tracing::{Level, Span};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+static INIT: Once = Once::new();
+static REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+static EXPERT_CALL_ID: AtomicU64 = AtomicU64::new(1);
+static LAYER_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Clone)]
+pub struct TraceLabels {
+    pub component: &'static str,
+    pub stage: &'static str,
+    pub path: &'static str,
+    pub request_id: u64,
+    pub layer_id: u64,
+    pub expert_call_id: u64,
+    pub expert_id: String,
+    pub worker: String,
+    pub num_tokens: usize,
+}
+
+impl TraceLabels {
+    pub fn new(component: &'static str, stage: &'static str) -> Self {
+        Self {
+            component,
+            stage,
+            path: "unknown",
+            request_id: 0,
+            layer_id: 0,
+            expert_call_id: 0,
+            expert_id: String::new(),
+            worker: String::new(),
+            num_tokens: 0,
+        }
+    }
+
+    pub fn path(mut self, path: &'static str) -> Self {
+        self.path = path;
+        self
+    }
+
+    pub fn request_id(mut self, request_id: u64) -> Self {
+        self.request_id = request_id;
+        self
+    }
+
+    pub fn layer_id(mut self, layer_id: u64) -> Self {
+        self.layer_id = layer_id;
+        self
+    }
+
+    pub fn expert_call_id(mut self, expert_call_id: u64) -> Self {
+        self.expert_call_id = expert_call_id;
+        self
+    }
+
+    pub fn expert_id(mut self, expert_id: impl Into<String>) -> Self {
+        self.expert_id = expert_id.into();
+        self
+    }
+
+    pub fn worker(mut self, worker: impl Into<String>) -> Self {
+        self.worker = worker.into();
+        self
+    }
+
+    pub fn num_tokens(mut self, num_tokens: usize) -> Self {
+        self.num_tokens = num_tokens;
+        self
+    }
+}
+
+pub struct StageTimer {
+    labels: TraceLabels,
+    start: Instant,
+    span: Span,
+}
+
+impl StageTimer {
+    pub fn start(labels: TraceLabels) -> Self {
+        let span = trace_span(&labels);
+        Self {
+            labels,
+            start: Instant::now(),
+            span,
+        }
+    }
+
+    pub fn span(&self) -> Span {
+        self.span.clone()
+    }
+}
+
+impl Drop for StageTimer {
+    fn drop(&mut self) {
+        let elapsed_us = self.start.elapsed().as_micros() as u64;
+        let labels = &self.labels;
+        self.span.in_scope(|| {
+            tracing::info!(
+                elapsed_us,
+                component = labels.component,
+                stage = labels.stage,
+                path = labels.path,
+                request_id = labels.request_id,
+                layer_id = labels.layer_id,
+                expert_call_id = labels.expert_call_id,
+                expert_id = labels.expert_id.as_str(),
+                worker = labels.worker.as_str(),
+                num_tokens = labels.num_tokens,
+                "expert-kit trace stage done",
+            );
+        });
+    }
+}
+
+pub fn init_tracing() {
+    INIT.call_once(|| {
+        let exporter = match opentelemetry_otlp::SpanExporter::builder()
+            .with_tonic()
+            .build()
+        {
+            Ok(exporter) => exporter,
+            Err(err) => {
+                log::warn!("[Tracing] failed to initialize OTLP exporter: {err}");
+                return;
+            }
+        };
+
+        let resource = Resource::builder()
+            .with_service_name("frontend")
+            .with_schema_url(
+                [
+                    KeyValue::new(SERVICE_VERSION, env!("CARGO_PKG_VERSION")),
+                    KeyValue::new(DEPLOYMENT_ENVIRONMENT_NAME, "develop"),
+                ],
+                SCHEMA_URL,
+            )
+            .build();
+        let provider = SdkTracerProvider::builder()
+            .with_sampler(Sampler::AlwaysOn)
+            .with_id_generator(RandomIdGenerator::default())
+            .with_resource(resource)
+            .with_batch_exporter(exporter)
+            .build();
+        let tracer = provider.tracer("expertkit-transport-rs");
+        let propagator = TextMapCompositePropagator::new(vec![
+            Box::new(BaggagePropagator::new()),
+            Box::new(TraceContextPropagator::new()),
+        ]);
+        opentelemetry::global::set_text_map_propagator(propagator);
+
+        if tracing_subscriber::registry()
+            .with(tracing_subscriber::filter::LevelFilter::from_level(
+                Level::INFO,
+            ))
+            .with(tracing_opentelemetry::layer().with_tracer(tracer))
+            .try_init()
+            .is_err()
+        {
+            log::debug!("[Tracing] tracing subscriber already initialized");
+        }
+    });
+}
+
+pub fn next_request_id() -> u64 {
+    REQUEST_ID.fetch_add(1, Ordering::SeqCst)
+}
+
+pub fn next_expert_call_id() -> u64 {
+    EXPERT_CALL_ID.fetch_add(1, Ordering::SeqCst)
+}
+
+pub fn next_layer_id() -> u64 {
+    LAYER_ID.fetch_add(1, Ordering::SeqCst)
+}
+
+pub fn trace_span(labels: &TraceLabels) -> Span {
+    tracing::span!(
+        Level::INFO,
+        "ek.trace",
+        otel.name = labels.stage,
+        component = labels.component,
+        stage = labels.stage,
+        path = labels.path,
+        request_id = labels.request_id,
+        layer_id = labels.layer_id,
+        expert_call_id = labels.expert_call_id,
+        expert_id = labels.expert_id.as_str(),
+        worker = labels.worker.as_str(),
+        num_tokens = labels.num_tokens,
+    )
+}
+
+pub fn inject_current_trace_context(metadata: &mut MetadataMap) {
+    let ctx = Span::current().context();
+    let mut injector = MetadataInjector(metadata);
+    opentelemetry::global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(&ctx, &mut injector);
+    });
+}
+
+pub fn infer_layer_id(expert_ids: &[Vec<String>], fallback: u64) -> u64 {
+    expert_ids
+        .iter()
+        .flatten()
+        .find_map(|expert_id| {
+            let marker = expert_id.rfind("/l")?;
+            let after_layer = &expert_id[marker + 2..];
+            let end = after_layer.find("-e").unwrap_or(after_layer.len());
+            after_layer[..end].parse::<u64>().ok()
+        })
+        .unwrap_or(fallback)
+}
+
+struct MetadataInjector<'a>(&'a mut MetadataMap);
+
+impl Injector for MetadataInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        if let Ok(key) = tonic::metadata::MetadataKey::from_bytes(key.as_bytes())
+            && let Ok(value) = value.parse()
+        {
+            self.0.insert(key, value);
+        }
+    }
+}

--- a/ek-integration/expertkit-transport-rs/src/python/bindings.rs
+++ b/ek-integration/expertkit-transport-rs/src/python/bindings.rs
@@ -2,6 +2,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyAny;
 
 use crate::client::ExpertKitClient as RustExpertKitClient;
+use crate::observability::init_tracing;
 use crate::utils::{TensorMetadata, pytorch_to_tch_tensor, tch_to_pytorch_tensor};
 
 const DEFAULT_THREAD_NUM: usize = 16;
@@ -39,6 +40,10 @@ impl PyExpertKitClient {
                     e
                 ))
             })?;
+        {
+            let _entered = runtime.enter();
+            init_tracing();
+        }
 
         Ok(Self {
             client: Some(RustExpertKitClient::new(controller_addr, timeout)),
@@ -109,7 +114,9 @@ impl PyExpertKitClient {
                 .block_on(async {
                     if use_fallback {
                         // Use fallback version for maximum resilience
-                        client.forward_expert_tensor_with_fallback(expert_ids, input_tensor).await
+                        client
+                            .forward_expert_tensor_with_fallback(expert_ids, input_tensor)
+                            .await
                     } else {
                         // Direct path only (still has retry logic)
                         client.forward_expert_tensor(expert_ids, input_tensor).await

--- a/ek-integration/expertkit-transport-rs/src/transport/grpc.rs
+++ b/ek-integration/expertkit-transport-rs/src/transport/grpc.rs
@@ -29,6 +29,8 @@ pub mod proto {
 
 use proto::ek::worker::v1::{ForwardReq, computation_service_client::ComputationServiceClient};
 
+use crate::observability::inject_current_trace_context;
+
 /// Connect timeout for establishing new gRPC connections (3 seconds)
 const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 
@@ -92,7 +94,10 @@ impl GrpcTransport {
     async fn invalidate_channel(&self, endpoint: &str) {
         let mut channels = self.channels.write().await;
         if channels.remove(endpoint).is_some() {
-            warn!("[GrpcTransport] Invalidated cached channel for {}", endpoint);
+            warn!(
+                "[GrpcTransport] Invalidated cached channel for {}",
+                endpoint
+            );
         }
     }
 }
@@ -148,6 +153,8 @@ impl Transport for GrpcTransport {
             );
 
             // Send with timeout
+            let mut grpc_req = tonic::Request::new(grpc_req);
+            inject_current_trace_context(grpc_req.metadata_mut());
             let result = tokio::time::timeout(self.timeout, client.forward(grpc_req)).await;
 
             match result {

--- a/ek-integration/expertkit-transport-rs/src/transport/mod.rs
+++ b/ek-integration/expertkit-transport-rs/src/transport/mod.rs
@@ -25,6 +25,9 @@ pub struct ExpertRequest {
     pub expert_id: String,
     pub tensor_data: Vec<u8>, // Safetensors blob containing batched sequences
     pub num_sequences: usize, // Number of sequences in this batch
+    pub request_id: u64,
+    pub layer_id: u64,
+    pub expert_call_id: u64,
 }
 
 impl ExpertRequest {
@@ -34,7 +37,22 @@ impl ExpertRequest {
             expert_id,
             tensor_data,
             num_sequences,
+            request_id: 0,
+            layer_id: 0,
+            expert_call_id: 0,
         }
+    }
+
+    pub fn with_trace_context(
+        mut self,
+        request_id: u64,
+        layer_id: u64,
+        expert_call_id: u64,
+    ) -> Self {
+        self.request_id = request_id;
+        self.layer_id = layer_id;
+        self.expert_call_id = expert_call_id;
+        self
     }
 }
 


### PR DESCRIPTION
## Summary

Add frontend/transport-side tracing for MoE request performance attribution.

OpenTelemetry tracing for the frontend Rust transport path, including request/layer/expert-level spans and transport stage spans.

## Changes

- Add shared tracing labels and stage timer utilities.
- Initialize OTLP tracing for the frontend transport client.
- Add frontend spans for:
  - `frontend.request`
  - `frontend.layer`
  - `frontend.decompose`
  - `frontend.route`
  - `frontend.expert_call`
  - `frontend.tensor_slice`
  - `frontend.serialize`
  - `frontend.send_worker`
  - `frontend.deserialize`
  - `frontend.merge`
- Inject trace context into worker/controller gRPC metadata from frontend transport.
- Add required OpenTelemetry dependencies.

## Validation

Validated on Qwen3-30B-A3B with Jaeger.

Trace:
`3826cb4bb1ffdf572713c6efae14ee92`

Observed services:
- `frontend`
- `worker`

Confirmed frontend span chain:
`frontend.send_worker -> frontend.expert_call -> frontend.layer -> frontend.request`

<img width="1678" height="711" alt="image" src="https://github.com/user-attachments/assets/87a848a0-0b27-499a-b9c1-9cce2da200d7" />

<img width="1679" height="528" alt="image" src="https://github.com/user-attachments/assets/dd074c48-2a75-421e-a96e-774f2165216b" />


Related to #131