### PR TITLE
Add worker-side tracing spans for MoE expert execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,6 +1495,7 @@ dependencies = [
  "ndarray",
  "ndarray-rand",
  "nix 0.30.1",
+ "opentelemetry",
  "ort",
  "ort-sys",
  "prometheus",
@@ -1630,6 +1631,10 @@ dependencies = [
  "log",
  "ndarray",
  "nix 0.29.0",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
  "parking_lot",
  "prost 0.12.6",
  "pyo3",
@@ -1644,6 +1649,9 @@ dependencies = [
  "tonic 0.11.0",
  "tonic-build 0.11.0",
  "tower 0.4.13",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/ek-computation/Cargo.toml
+++ b/ek-computation/Cargo.toml
@@ -45,6 +45,7 @@ tonic = { workspace = true }
 tower = { workspace = true }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
+opentelemetry = { workspace = true }
 url = { workspace = true }
 
 [build-dependencies]

--- a/ek-computation/src/lib.rs
+++ b/ek-computation/src/lib.rs
@@ -2,6 +2,7 @@ pub mod backend;
 pub mod controller;
 pub mod ffn;
 pub mod metrics;
+pub mod observability;
 pub mod onnx;
 pub mod proto;
 mod schema;

--- a/ek-computation/src/observability.rs
+++ b/ek-computation/src/observability.rs
@@ -1,0 +1,203 @@
+use std::{
+    collections::HashMap,
+    sync::atomic::{AtomicU64, Ordering},
+    time::Instant,
+};
+
+use opentelemetry::propagation::{Extractor, Injector};
+use tonic::metadata::MetadataMap;
+use tracing::{Level, Span};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+static REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+static EXPERT_CALL_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Clone)]
+pub struct TraceLabels {
+    pub component: &'static str,
+    pub stage: &'static str,
+    pub path: &'static str,
+    pub request_id: u64,
+    pub layer_id: u64,
+    pub expert_call_id: u64,
+    pub expert_id: String,
+    pub worker: String,
+    pub num_tokens: usize,
+}
+
+impl TraceLabels {
+    pub fn new(component: &'static str, stage: &'static str) -> Self {
+        Self {
+            component,
+            stage,
+            path: "unknown",
+            request_id: 0,
+            layer_id: 0,
+            expert_call_id: 0,
+            expert_id: String::new(),
+            worker: String::new(),
+            num_tokens: 0,
+        }
+    }
+
+    pub fn path(mut self, path: &'static str) -> Self {
+        self.path = path;
+        self
+    }
+
+    pub fn request_id(mut self, request_id: u64) -> Self {
+        self.request_id = request_id;
+        self
+    }
+
+    pub fn layer_id(mut self, layer_id: u64) -> Self {
+        self.layer_id = layer_id;
+        self
+    }
+
+    pub fn expert_call_id(mut self, expert_call_id: u64) -> Self {
+        self.expert_call_id = expert_call_id;
+        self
+    }
+
+    pub fn expert_id(mut self, expert_id: impl Into<String>) -> Self {
+        self.expert_id = expert_id.into();
+        self
+    }
+
+    pub fn worker(mut self, worker: impl Into<String>) -> Self {
+        self.worker = worker.into();
+        self
+    }
+
+    pub fn num_tokens(mut self, num_tokens: usize) -> Self {
+        self.num_tokens = num_tokens;
+        self
+    }
+}
+
+pub struct StageTimer {
+    labels: TraceLabels,
+    start: Instant,
+    span: Span,
+}
+
+impl StageTimer {
+    pub fn start(labels: TraceLabels) -> Self {
+        let span = trace_span(&labels);
+        Self::start_with_span(labels, span)
+    }
+
+    pub fn start_with_span(labels: TraceLabels, span: Span) -> Self {
+        Self {
+            labels,
+            start: Instant::now(),
+            span,
+        }
+    }
+
+    pub fn span(&self) -> Span {
+        self.span.clone()
+    }
+}
+
+impl Drop for StageTimer {
+    fn drop(&mut self) {
+        let elapsed_us = self.start.elapsed().as_micros() as u64;
+        let labels = &self.labels;
+        self.span.in_scope(|| {
+            tracing::info!(
+                elapsed_us,
+                component = labels.component,
+                stage = labels.stage,
+                path = labels.path,
+                request_id = labels.request_id,
+                layer_id = labels.layer_id,
+                expert_call_id = labels.expert_call_id,
+                expert_id = labels.expert_id.as_str(),
+                worker = labels.worker.as_str(),
+                num_tokens = labels.num_tokens,
+                "expert-kit trace stage done",
+            );
+        });
+    }
+}
+
+pub fn next_request_id() -> u64 {
+    REQUEST_ID.fetch_add(1, Ordering::SeqCst)
+}
+
+pub fn next_expert_call_id() -> u64 {
+    EXPERT_CALL_ID.fetch_add(1, Ordering::SeqCst)
+}
+
+pub fn trace_span(labels: &TraceLabels) -> Span {
+    tracing::span!(
+        Level::INFO,
+        "ek.trace",
+        otel.name = labels.stage,
+        component = labels.component,
+        stage = labels.stage,
+        path = labels.path,
+        request_id = labels.request_id,
+        layer_id = labels.layer_id,
+        expert_call_id = labels.expert_call_id,
+        expert_id = labels.expert_id.as_str(),
+        worker = labels.worker.as_str(),
+        num_tokens = labels.num_tokens,
+    )
+}
+
+pub fn child_span_from_traceparent(labels: &TraceLabels, traceparent: &str) -> Span {
+    let span = trace_span(labels);
+    if !traceparent.is_empty() {
+        let mut headers = HashMap::new();
+        headers.insert("traceparent".to_string(), traceparent.to_string());
+        let extractor = StringMapExtractor(headers);
+        let ctx = opentelemetry::global::get_text_map_propagator(|propagator| {
+            propagator.extract(&extractor)
+        });
+        span.set_parent(ctx);
+    }
+    span
+}
+
+pub fn extract_traceparent(metadata: &MetadataMap) -> String {
+    metadata
+        .get("traceparent")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_string()
+}
+
+pub fn inject_current_trace_context(metadata: &mut MetadataMap) {
+    let ctx = Span::current().context();
+    let mut injector = MetadataInjector(metadata);
+    opentelemetry::global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(&ctx, &mut injector);
+    });
+}
+
+struct MetadataInjector<'a>(&'a mut MetadataMap);
+
+impl Injector for MetadataInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        if let Ok(key) = tonic::metadata::MetadataKey::from_bytes(key.as_bytes())
+            && let Ok(value) = value.parse()
+        {
+            self.0.insert(key, value);
+        }
+    }
+}
+
+struct StringMapExtractor(HashMap<String, String>);
+
+impl Extractor for StringMapExtractor {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).map(String::as_str)
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(String::as_str).collect()
+    }
+}

--- a/ek-computation/src/worker/core.rs
+++ b/ek-computation/src/worker/core.rs
@@ -1,10 +1,13 @@
 use super::manager::{ExpertDB, ExpertDBSync, get_expert_db, get_expert_db_sync};
-use crate::{controller::registry::ExpertIdRef, proto::ek};
+use crate::{
+    controller::registry::ExpertIdRef,
+    observability::{StageTimer, TraceLabels},
+    proto::ek,
+};
 use core::fmt;
 use ek_base::error::EKResult;
 use std::sync::{Arc, OnceLock};
 use tokio;
-use tracing::instrument;
 
 /// Async version of EKInstanceGate for non-compute operations
 pub struct EKInstanceGateAsync {
@@ -73,7 +76,6 @@ impl EKInstanceGateSync {
     }
 
     /// Synchronous forward computation - optimized for compute-intensive tasks
-    #[instrument(skip(self, req))]
     pub fn forward_sync(
         &self,
         req: ek::worker::v1::ForwardReq,
@@ -91,17 +93,52 @@ impl EKInstanceGateSync {
         assert!(!req.sequences.is_empty());
         assert!(req.sequences[0].experts.len() == 1);
         let exp_id = &req.sequences[0].experts[0];
+        let settings = ek_base::config::get_ek_settings();
+        let num_tokens = req.sequences.len();
 
         // Load expert synchronously from shared database
-        let exp = self.experts.load(exp_id)?;
+        let exp = {
+            let timer = StageTimer::start(
+                TraceLabels::new("worker", "worker.load_expert")
+                    .path("worker")
+                    .worker(settings.worker.id.as_str())
+                    .expert_id(exp_id)
+                    .num_tokens(num_tokens),
+            );
+            let span = timer.span();
+            let _entered = span.enter();
+            self.experts.load(exp_id)?
+        };
 
         let now = std::time::Instant::now();
         tracing::debug!("[L3 {:?}] exp_backend.forward_sync() started", exp_id,);
 
         // Perform synchronous computation
-        let st = safetensors::SafeTensors::deserialize(&input_tensor).unwrap();
+        let st = {
+            let timer = StageTimer::start(
+                TraceLabels::new("worker", "worker.deserialize")
+                    .path("worker")
+                    .worker(settings.worker.id.as_str())
+                    .expert_id(exp_id)
+                    .num_tokens(num_tokens),
+            );
+            let span = timer.span();
+            let _entered = span.enter();
+            safetensors::SafeTensors::deserialize(&input_tensor)?
+        };
         let tv = st.tensor("data")?;
-        let res = exp.forward(&tv)?;
+        let res = {
+            let timer = StageTimer::start(
+                TraceLabels::new("worker", "worker.compute")
+                    .path("worker")
+                    .worker(settings.worker.id.as_str())
+                    .expert_id(exp_id)
+                    .num_tokens(num_tokens),
+            );
+            let span = timer.span();
+            let _entered = span.enter();
+            exp.forward(&tv)?
+        };
 
         tracing::debug!(
             "[L3 {:?}] exp_backend.forward_sync() completed in {:?}",
@@ -113,8 +150,19 @@ impl EKInstanceGateSync {
 
         tracing::debug!("output bytes_len={}", output_bytes.len());
 
-        let resp = ek::worker::v1::ForwardResp {
-            output_tensor: output_bytes,
+        let resp = {
+            let timer = StageTimer::start(
+                TraceLabels::new("worker", "worker.serialize")
+                    .path("worker")
+                    .worker(settings.worker.id.as_str())
+                    .expert_id(exp_id)
+                    .num_tokens(num_tokens),
+            );
+            let span = timer.span();
+            let _entered = span.enter();
+            ek::worker::v1::ForwardResp {
+                output_tensor: output_bytes,
+            }
         };
 
         tracing::debug!(
@@ -131,10 +179,49 @@ impl EKInstanceGateSync {
         expert_id: ExpertIdRef<'_>,
         input_tensor: &[u8],
     ) -> EKResult<Vec<u8>> {
-        let exp = self.experts.load(expert_id)?;
-        let st = safetensors::SafeTensors::deserialize(input_tensor)?;
+        let settings = ek_base::config::get_ek_settings();
+        let exp = {
+            let timer = StageTimer::start(
+                TraceLabels::new("worker", "worker.load_expert")
+                    .path("worker")
+                    .worker(settings.worker.id.as_str())
+                    .expert_id(expert_id),
+            );
+            let span = timer.span();
+            let _entered = span.enter();
+            self.experts.load(expert_id)?
+        };
+        let st = {
+            let timer = StageTimer::start(
+                TraceLabels::new("worker", "worker.deserialize")
+                    .path("worker")
+                    .worker(settings.worker.id.as_str())
+                    .expert_id(expert_id),
+            );
+            let span = timer.span();
+            let _entered = span.enter();
+            safetensors::SafeTensors::deserialize(input_tensor)?
+        };
         let tv = st.tensor("data")?;
-        let res = exp.forward(&tv)?;
+        let res = {
+            let timer = StageTimer::start(
+                TraceLabels::new("worker", "worker.compute")
+                    .path("worker")
+                    .worker(settings.worker.id.as_str())
+                    .expert_id(expert_id),
+            );
+            let span = timer.span();
+            let _entered = span.enter();
+            exp.forward(&tv)?
+        };
+        let timer = StageTimer::start(
+            TraceLabels::new("worker", "worker.serialize")
+                .path("worker")
+                .worker(settings.worker.id.as_str())
+                .expert_id(expert_id),
+        );
+        let span = timer.span();
+        let _entered = span.enter();
         Ok(res)
     }
 

--- a/ek-computation/src/worker/mod.rs
+++ b/ek-computation/src/worker/mod.rs
@@ -32,8 +32,7 @@ use ek_base::{config::get_ek_settings, error::EKResult};
 
 /// Set to true on SIGTERM; the heartbeat stream reads this and sets last_will=true
 /// in all subsequent heartbeats so the controller can start proactive migration.
-static LAST_WILL: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
+static LAST_WILL: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
 pub fn get_last_will() -> bool {
     LAST_WILL.load(Ordering::Relaxed)
@@ -158,9 +157,8 @@ pub async fn worker_main() -> EKResult<()> {
     {
         let wm_listen = settings.weight.wm_listen.clone();
         let wm_clone = wm.clone();
-        let wm_addr: std::net::SocketAddr = wm_listen
-            .parse()
-            .expect("invalid weight.wm_listen address");
+        let wm_addr: std::net::SocketAddr =
+            wm_listen.parse().expect("invalid weight.wm_listen address");
         tokio::spawn(async move {
             log::info!("Peer weight HTTP server listening on {wm_addr}");
             match peer_server::start_peer_server(wm_clone, &wm_addr).await {
@@ -201,12 +199,8 @@ pub async fn worker_main() -> EKResult<()> {
         log::info!("ek hostname: {worker_id:}");
         let control_endpoint = x::get_controller_addr();
         log::info!("control endpoint {:}", control_endpoint.uri());
-        let mut state_client = StateClient::new_with_rdma_tcp_port(
-            control_endpoint,
-            &worker_id,
-            rdma_tcp_port,
-            wm,
-        );
+        let mut state_client =
+            StateClient::new_with_rdma_tcp_port(control_endpoint, &worker_id, rdma_tcp_port, wm);
         state_client.set_preemption_notifier(preemption_tx);
         if let Err(e) = state_client.run(cli_cancel).await {
             log::error!("state client error {e:}");
@@ -433,9 +427,9 @@ pub async fn worker_main() -> EKResult<()> {
     tokio::spawn(async move {
         #[cfg(unix)]
         {
-            if let Ok(mut sig) = tokio::signal::unix::signal(
-                tokio::signal::unix::SignalKind::terminate(),
-            ) {
+            if let Ok(mut sig) =
+                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            {
                 sig.recv().await;
                 let _ = sigterm_tx.send(());
                 return;
@@ -471,7 +465,9 @@ pub async fn worker_main() -> EKResult<()> {
         match tokio::time::timeout(
             Duration::from_secs(settings.worker.shutdown_grace_secs),
             preemption_rx,
-        ).await {
+        )
+        .await
+        {
             Ok(Ok(())) => {
                 log::info!("Controller confirmed preemption complete");
             }

--- a/ek-computation/src/worker/server.rs
+++ b/ek-computation/src/worker/server.rs
@@ -11,13 +11,13 @@ use dashmap::DashMap;
 
 use crate::{
     metrics::{METRIC_WORKER_EXPERT_ACTIVATION, METRIC_WORKER_FORWARD},
+    observability::{StageTimer, TraceLabels, child_span_from_traceparent, extract_traceparent},
     proto::ek::worker::v1::{
         ForwardReq, ForwardResp, computation_service_server::ComputationService,
     },
 };
 use ek_base::utils::Defers;
 use tonic::{Request, Response, Status};
-use tracing::instrument;
 
 /// Per-expert request counters, reset after each heartbeat snapshot.
 static REQUEST_COUNTS: LazyLock<DashMap<String, AtomicU64>> = LazyLock::new(DashMap::new);
@@ -36,7 +36,6 @@ pub fn snapshot_and_reset() -> HashMap<String, u64> {
 }
 
 use super::core::{EKInstanceGateSync, get_instance_gate_sync};
-use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 #[derive(Debug)]
 pub struct BasicExpertImpl {
@@ -59,7 +58,6 @@ impl BasicExpertImpl {
 
 #[tonic::async_trait]
 impl ComputationService for BasicExpertImpl {
-    #[instrument(skip(self, request))]
     async fn forward(&self, request: Request<ForwardReq>) -> Result<Response<ForwardResp>, Status> {
         let now = Instant::now();
         let exp_id = request.get_ref().sequences[0].experts[0].clone();
@@ -83,6 +81,16 @@ impl BasicExpertImpl {
         );
         let exp_id = request.get_ref().sequences[0].experts[0].clone();
         let start = Instant::now();
+        let settings = ek_base::config::get_ek_settings();
+        let num_tokens = request.get_ref().sequences.len();
+        let traceparent = extract_traceparent(request.metadata());
+        let forward_labels = TraceLabels::new("worker", "worker.forward")
+            .path("worker")
+            .worker(settings.worker.id.as_str())
+            .expert_id(exp_id.as_str())
+            .num_tokens(num_tokens);
+        let forward_span = child_span_from_traceparent(&forward_labels, traceparent.as_str());
+        let _forward_timer = StageTimer::start_with_span(forward_labels, forward_span.clone());
 
         // Increment per-expert counter (reset each heartbeat)
         REQUEST_COUNTS
@@ -91,7 +99,6 @@ impl BasicExpertImpl {
             .fetch_add(1, Ordering::Relaxed);
 
         let start_cloned = start;
-        let settings = ek_base::config::get_ek_settings();
 
         // Record metrics
         METRIC_WORKER_EXPERT_ACTIVATION
@@ -135,15 +142,22 @@ impl BasicExpertImpl {
         // Use sync gate for compute-intensive operations
         let gate_sync = self.gate_sync;
 
-        // Capture current tracing context for the blocking task
-        let cx = tracing::Span::current().context();
-
-        let cx_clone = cx.clone();
+        let forward_span_for_task = forward_span.clone();
+        let queue_wait_timer = {
+            let _entered = forward_span.enter();
+            StageTimer::start(
+                TraceLabels::new("worker", "worker.queue_wait")
+                    .path("worker")
+                    .worker(settings.worker.id.as_str())
+                    .expert_id(exp_id.as_str())
+                    .num_tokens(num_tokens),
+            )
+        };
 
         // Run synchronous computation in blocking task
         let res = tokio::task::spawn_blocking(move || {
-            let _guard = cx_clone.attach();
-
+            drop(queue_wait_timer);
+            let _entered = forward_span_for_task.enter();
             // Perform synchronous forward computation
             gate_sync.forward_sync(req_inner)
         })

--- a/ek-integration/expertkit-transport-rs/Cargo.toml
+++ b/ek-integration/expertkit-transport-rs/Cargo.toml
@@ -22,6 +22,13 @@ serde_json = "1.0"
 anyhow = "1.0"
 log = { workspace = true }
 env_logger = { workspace = true }
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true }
+opentelemetry-otlp = { workspace = true }
+opentelemetry-semantic-conventions = { workspace = true }
+tracing = { workspace = true }
+tracing-opentelemetry = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 # gRPC dependencies (Phase 2)
 tonic = "0.11"

--- a/ek-integration/expertkit-transport-rs/src/client.rs
+++ b/ek-integration/expertkit-transport-rs/src/client.rs
@@ -4,15 +4,71 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tonic::transport::Channel;
+use tracing::{Instrument, Span};
 
-use crate::routing::RoutingClient;
-use crate::transport::{ExpertRequest, Transport, auto::AutoTransport};
-use crate::transport::grpc::proto::ek::worker::v1::{
-    ForwardReq, forward_req::SequenceInfo, computation_service_client::ComputationServiceClient,
+use crate::observability::{
+    StageTimer, TraceLabels, infer_layer_id, inject_current_trace_context, next_expert_call_id,
+    next_layer_id, next_request_id,
 };
+use crate::routing::RoutingClient;
+use crate::transport::grpc::proto::ek::worker::v1::{
+    ForwardReq, computation_service_client::ComputationServiceClient, forward_req::SequenceInfo,
+};
+use crate::transport::{ExpertRequest, Transport, auto::AutoTransport};
 use crate::utils::{deserialize_safetensor_2_tch_tensor, serialize_tch_tensor_2_safetensor};
 
 use tch::Tensor;
+
+struct ForwardTrace {
+    request_id: u64,
+    layer_id: u64,
+    layer_span: Span,
+    _request_timer: StageTimer,
+    _layer_timer: StageTimer,
+}
+
+impl ForwardTrace {
+    fn start(
+        expert_ids: &[Vec<String>],
+        batch_size: usize,
+        hidden_dim: usize,
+        path: &'static str,
+    ) -> Self {
+        let request_id = next_request_id();
+        let inferred_layer_id = infer_layer_id(expert_ids, next_layer_id());
+        let request_timer = StageTimer::start(
+            TraceLabels::new("frontend", "frontend.request")
+                .path(path)
+                .request_id(request_id)
+                .layer_id(inferred_layer_id)
+                .num_tokens(batch_size),
+        );
+        let request_span = request_timer.span();
+        let layer_timer = {
+            let _entered = request_span.enter();
+            StageTimer::start(
+                TraceLabels::new("frontend", "frontend.layer")
+                    .path(path)
+                    .request_id(request_id)
+                    .layer_id(inferred_layer_id)
+                    .num_tokens(batch_size),
+            )
+        };
+        let _ = hidden_dim;
+        Self {
+            request_id,
+            layer_id: inferred_layer_id,
+            layer_span: layer_timer.span(),
+            _request_timer: request_timer,
+            _layer_timer: layer_timer,
+        }
+    }
+
+    fn child_timer(&self, labels: TraceLabels) -> StageTimer {
+        let _entered = self.layer_span.enter();
+        StageTimer::start(labels.request_id(self.request_id).layer_id(self.layer_id))
+    }
+}
 
 /// Result of a single expert task execution
 enum ExpertTaskResult {
@@ -54,7 +110,9 @@ impl ExpertKitClient {
         routing.fetch_routing(None).await?;
 
         // Establish controller channel for fallback requests
-        let uri = if self.controller_addr.starts_with("http://") || self.controller_addr.starts_with("https://") {
+        let uri = if self.controller_addr.starts_with("http://")
+            || self.controller_addr.starts_with("https://")
+        {
             self.controller_addr.clone()
         } else {
             format!("http://{}", self.controller_addr)
@@ -86,6 +144,9 @@ impl ExpertKitClient {
         routing: Arc<RoutingClient>,
         pre_assigned_worker: crate::transport::grpc::proto::ek::control::v1::WorkerEndpoint,
         task_create_t: std::time::Instant,
+        request_id: u64,
+        layer_id: u64,
+        expert_call_id: u64,
     ) -> ExpertTaskResult {
         let sub_task_t = std::time::Instant::now();
 
@@ -107,19 +168,51 @@ impl ExpertKitClient {
             .collect();
 
         // Create index tensor and slice
-        let index_tensor = Tensor::from_slice(&seq_indices);
-        let expert_input = hidden_state.index_select(0, &index_tensor);
+        let expert_input = {
+            let timer = StageTimer::start(
+                TraceLabels::new("frontend", "frontend.tensor_slice")
+                    .path("direct_worker")
+                    .request_id(request_id)
+                    .layer_id(layer_id)
+                    .expert_call_id(expert_call_id)
+                    .expert_id(expert_id.as_str())
+                    .worker(worker_endpoint.grpc_addr.as_str())
+                    .num_tokens(seq_indices.len()),
+            );
+            let span = timer.span();
+            let _entered = span.enter();
+            let index_tensor = Tensor::from_slice(&seq_indices);
+            let tensor = hidden_state.index_select(0, &index_tensor);
+            drop(timer);
+            tensor
+        };
 
         // Serialize for network transfer
-        let tensor_bytes = match serialize_tch_tensor_2_safetensor(&expert_input) {
-            Ok(bytes) => bytes,
-            Err(e) => {
-                return ExpertTaskResult::Failed(
-                    expert_id,
-                    format!("Failed to serialize tensor: {}", e),
-                    Some(worker_endpoint.grpc_addr.clone()),
-                );
-            }
+        let tensor_bytes = {
+            let timer = StageTimer::start(
+                TraceLabels::new("frontend", "frontend.serialize")
+                    .path("direct_worker")
+                    .request_id(request_id)
+                    .layer_id(layer_id)
+                    .expert_call_id(expert_call_id)
+                    .expert_id(expert_id.as_str())
+                    .worker(worker_endpoint.grpc_addr.as_str())
+                    .num_tokens(seq_indices.len()),
+            );
+            let span = timer.span();
+            let _entered = span.enter();
+            let result = match serialize_tch_tensor_2_safetensor(&expert_input) {
+                Ok(bytes) => bytes,
+                Err(e) => {
+                    return ExpertTaskResult::Failed(
+                        expert_id,
+                        format!("Failed to serialize tensor: {}", e),
+                        Some(worker_endpoint.grpc_addr.clone()),
+                    );
+                }
+            };
+            drop(timer);
+            result
         };
         let num_sequences = seq_indices.len();
 
@@ -133,23 +226,52 @@ impl ExpertKitClient {
         );
 
         // Create request
-        let request = ExpertRequest::new(expert_id.clone(), tensor_bytes, num_sequences);
+        let request = ExpertRequest::new(expert_id.clone(), tensor_bytes, num_sequences)
+            .with_trace_context(request_id, layer_id, expert_call_id);
 
         let send_t = std::time::Instant::now();
+        let send_timer = StageTimer::start(
+            TraceLabels::new("frontend", "frontend.send_worker")
+                .path("direct_worker")
+                .request_id(request_id)
+                .layer_id(layer_id)
+                .expert_call_id(expert_call_id)
+                .expert_id(expert_id.as_str())
+                .worker(worker_endpoint.grpc_addr.as_str())
+                .num_tokens(num_sequences),
+        );
+        let send_span = send_timer.span();
         let result = transport
             .send_batch(&worker_endpoint, vec![request])
+            .instrument(send_span)
             .await;
+        drop(send_timer);
         let rtt_ms = send_t.elapsed().as_secs_f64() * 1000.0;
 
         // Track request completion (decrement inflight, update RTT and throughput)
-        routing.on_request_complete(&worker_endpoint, rtt_ms, num_sequences).await;
+        routing
+            .on_request_complete(&worker_endpoint, rtt_ms, num_sequences)
+            .await;
 
         let addr = worker_endpoint.grpc_addr.clone();
         match result {
             Ok(responses) => {
                 if let Some(response) = responses.into_iter().next() {
+                    let timer = StageTimer::start(
+                        TraceLabels::new("frontend", "frontend.deserialize")
+                            .path("direct_worker")
+                            .request_id(request_id)
+                            .layer_id(layer_id)
+                            .expert_call_id(expert_call_id)
+                            .expert_id(expert_id.as_str())
+                            .worker(addr.as_str())
+                            .num_tokens(num_sequences),
+                    );
+                    let span = timer.span();
+                    let _entered = span.enter();
                     match deserialize_safetensor_2_tch_tensor(&response.tensor_data) {
                         Ok(tensor) => {
+                            drop(timer);
                             debug!(
                                 "[Client-Time] 🔚 Sub-task for expert {} on worker {} completed in {:?} μs, send_batch took {:?} μs (RTT={:.2}ms), cost from task create time {:?} μs",
                                 expert_id,
@@ -161,14 +283,21 @@ impl ExpertKitClient {
                             );
                             ExpertTaskResult::Success(expert_id, tensor)
                         }
-                        Err(e) => ExpertTaskResult::Failed(
-                            expert_id,
-                            format!("Failed to deserialize response: {}", e),
-                            Some(addr),
-                        ),
+                        Err(e) => {
+                            drop(timer);
+                            ExpertTaskResult::Failed(
+                                expert_id,
+                                format!("Failed to deserialize response: {}", e),
+                                Some(addr),
+                            )
+                        }
                     }
                 } else {
-                    ExpertTaskResult::Failed(expert_id, "Empty response from worker".to_string(), Some(addr))
+                    ExpertTaskResult::Failed(
+                        expert_id,
+                        "Empty response from worker".to_string(),
+                        Some(addr),
+                    )
                 }
             }
             Err(e) => {
@@ -176,7 +305,11 @@ impl ExpertKitClient {
                     "[Client] Expert {} failed on worker {}: {}",
                     expert_id, addr, e
                 );
-                ExpertTaskResult::Failed(expert_id, format!("Worker request failed: {}", e), Some(addr))
+                ExpertTaskResult::Failed(
+                    expert_id,
+                    format!("Worker request failed: {}", e),
+                    Some(addr),
+                )
             }
         }
     }
@@ -190,6 +323,19 @@ impl ExpertKitClient {
     ) -> Result<Tensor> {
         let batch_size = hidden_state.size()[0] as usize;
         let hidden_dim = hidden_state.size()[1] as usize;
+        let trace = ForwardTrace::start(&expert_ids, batch_size, hidden_dim, "direct_worker");
+        self.forward_expert_tensor_direct(expert_ids, hidden_state, &trace)
+            .await
+    }
+
+    async fn forward_expert_tensor_direct(
+        &self,
+        expert_ids: Vec<Vec<String>>,
+        hidden_state: Tensor,
+        trace: &ForwardTrace,
+    ) -> Result<Tensor> {
+        let batch_size = hidden_state.size()[0] as usize;
+        let hidden_dim = hidden_state.size()[1] as usize;
 
         debug!(
             "[Client] forward_expert_tensor: batch_size={}, hidden_dim={}, device={:?}",
@@ -199,16 +345,26 @@ impl ExpertKitClient {
         );
 
         // Decompose by expert
-        let mut expert_to_sequences: HashMap<String, Vec<(usize, usize)>> = HashMap::new();
-
-        for (seq_idx, experts) in expert_ids.iter().enumerate() {
-            for (expert_idx, expert_id) in experts.iter().enumerate() {
-                expert_to_sequences
-                    .entry(expert_id.clone())
-                    .or_default()
-                    .push((seq_idx, expert_idx));
+        let expert_to_sequences: HashMap<String, Vec<(usize, usize)>> = {
+            let timer = trace.child_timer(
+                TraceLabels::new("frontend", "frontend.decompose")
+                    .path("direct_worker")
+                    .num_tokens(expert_ids.len()),
+            );
+            let span = timer.span();
+            let _entered = span.enter();
+            let mut expert_to_sequences: HashMap<String, Vec<(usize, usize)>> = HashMap::new();
+            for (seq_idx, experts) in expert_ids.iter().enumerate() {
+                for (expert_idx, expert_id) in experts.iter().enumerate() {
+                    expert_to_sequences
+                        .entry(expert_id.clone())
+                        .or_default()
+                        .push((seq_idx, expert_idx));
+                }
             }
-        }
+            drop(timer);
+            expert_to_sequences
+        };
 
         info!(
             "[Client] Decomposed {} sequences into {} unique experts",
@@ -250,7 +406,18 @@ impl ExpertKitClient {
             .iter()
             .map(|(eid, positions)| (eid.clone(), positions.len()))
             .collect();
-        let mut assignments = self.routing.assign_layer_batch(&expert_calls).await;
+        let routing_timer = trace.child_timer(
+            TraceLabels::new("frontend", "frontend.route")
+                .path("direct_worker")
+                .num_tokens(expert_calls.len()),
+        );
+        let routing_span = routing_timer.span();
+        let mut assignments = self
+            .routing
+            .assign_layer_batch(&expert_calls)
+            .instrument(routing_span)
+            .await;
+        drop(routing_timer);
 
         // Build requests: slice tensor directly and spawn tasks immediately
         let mut jobs: tokio::task::JoinSet<ExpertTaskResult> = tokio::task::JoinSet::new();
@@ -267,13 +434,24 @@ impl ExpertKitClient {
             let worker = match assignments.remove(expert_id) {
                 Some(w) => w,
                 None => {
-                    warn!("[Client] Expert {} missing from LPT assignment, falling back to dynamic selection", expert_id);
-                    match self.routing.select_worker_and_mark_inflight(expert_id).await {
+                    warn!(
+                        "[Client] Expert {} missing from LPT assignment, falling back to dynamic selection",
+                        expert_id
+                    );
+                    match self
+                        .routing
+                        .select_worker_and_mark_inflight(expert_id)
+                        .await
+                    {
                         Some(w) => w,
                         None => {
                             let eid = expert_id.clone();
                             jobs.spawn(async move {
-                                ExpertTaskResult::Failed(eid, "No worker available".to_string(), None)
+                                ExpertTaskResult::Failed(
+                                    eid,
+                                    "No worker available".to_string(),
+                                    None,
+                                )
                             });
                             continue;
                         }
@@ -286,8 +464,26 @@ impl ExpertKitClient {
             let seq_positions_clone = seq_positions.clone();
             let transport = self.transport.clone();
             let routing = self.routing.clone();
+            let request_id = trace.request_id;
+            let layer_id = trace.layer_id;
+            let expert_call_id = next_expert_call_id();
+            let expert_timer = {
+                let _entered = trace.layer_span.enter();
+                StageTimer::start(
+                    TraceLabels::new("frontend", "frontend.expert_call")
+                        .path("direct_worker")
+                        .request_id(request_id)
+                        .layer_id(layer_id)
+                        .expert_call_id(expert_call_id)
+                        .expert_id(expert_id.as_str())
+                        .worker(worker.grpc_addr.as_str())
+                        .num_tokens(seq_positions.len()),
+                )
+            };
+            let expert_span = expert_timer.span();
 
             jobs.spawn(async move {
+                let _expert_timer = expert_timer;
                 Self::execute_expert_task(
                     expert_id_clone,
                     seq_positions_clone,
@@ -296,7 +492,11 @@ impl ExpertKitClient {
                     routing,
                     worker,
                     task_create_t,
+                    request_id,
+                    layer_id,
+                    expert_call_id,
                 )
+                .instrument(expert_span)
                 .await
             });
         }
@@ -339,10 +539,7 @@ impl ExpertKitClient {
         // a worker loads the expert.  Retrying on the frontend is wasteful
         // because it re-selects from a potentially stale routing table.
         if !failed_experts.is_empty() {
-            let failed_ids: Vec<String> = failed_experts
-                .into_iter()
-                .map(|(id, _)| id)
-                .collect();
+            let failed_ids: Vec<String> = failed_experts.into_iter().map(|(id, _)| id).collect();
             warn!(
                 "[Client] {} expert tasks failed on direct path, deferring to controller fallback: {:?}",
                 failed_ids.len(),
@@ -376,6 +573,13 @@ impl ExpertKitClient {
         );
 
         let t = std::time::Instant::now();
+        let merge_timer = trace.child_timer(
+            TraceLabels::new("frontend", "frontend.merge")
+                .path("direct_worker")
+                .num_tokens(batch_size),
+        );
+        let merge_span = merge_timer.span();
+        let _merge_entered = merge_span.enter();
         for (expert_id_resp, resp_tensor) in successful_results.iter() {
             let seq_positions = expert_metadata
                 .get(expert_id_resp)
@@ -420,6 +624,7 @@ impl ExpertKitClient {
             "[Client-Time] 🧩 Completed stacking of final output tensors in {:?} μs",
             t.elapsed().as_micros()
         );
+        drop(merge_timer);
 
         Ok(final_output)
     }
@@ -466,12 +671,24 @@ impl ExpertKitClient {
         &self,
         expert_ids: &[Vec<String>],
         hidden_state: &Tensor,
+        trace: &ForwardTrace,
     ) -> Result<Tensor> {
-        let channel = self.controller_channel.as_ref()
+        let channel = self
+            .controller_channel
+            .as_ref()
             .ok_or_else(|| anyhow::anyhow!("Controller channel not established"))?;
 
         // Serialize the hidden state tensor
-        let tensor_bytes = serialize_tch_tensor_2_safetensor(hidden_state)?;
+        let serialize_timer = trace.child_timer(
+            TraceLabels::new("frontend", "frontend.serialize")
+                .path("fallback_controller")
+                .num_tokens(expert_ids.len()),
+        );
+        let serialize_span = serialize_timer.span();
+        let tensor_bytes = async { serialize_tch_tensor_2_safetensor(hidden_state) }
+            .instrument(serialize_span)
+            .await?;
+        drop(serialize_timer);
 
         // Build sequences info for the request
         let sequences: Vec<SequenceInfo> = expert_ids
@@ -499,13 +716,37 @@ impl ExpertKitClient {
             .max_encoding_message_size(max_message_size);
 
         // Send with timeout
-        let response = tokio::time::timeout(self.timeout, client.forward(req))
-            .await
-            .map_err(|_| anyhow::anyhow!("Controller fallback timeout after {:?}", self.timeout))?
-            .map_err(|e| anyhow::anyhow!("Controller fallback gRPC error: {}", e))?;
+        let send_timer = trace.child_timer(
+            TraceLabels::new("frontend", "frontend.send_controller")
+                .path("fallback_controller")
+                .num_tokens(expert_ids.len()),
+        );
+        let send_span = send_timer.span();
+        let response = tokio::time::timeout(
+            self.timeout,
+            async {
+                let mut req = tonic::Request::new(req);
+                inject_current_trace_context(req.metadata_mut());
+                client.forward(req).await
+            }
+            .instrument(send_span),
+        )
+        .await
+        .map_err(|_| anyhow::anyhow!("Controller fallback timeout after {:?}", self.timeout))?
+        .map_err(|e| anyhow::anyhow!("Controller fallback gRPC error: {}", e))?;
+        drop(send_timer);
 
         let output_tensor = response.into_inner().output_tensor;
-        let result = deserialize_safetensor_2_tch_tensor(&output_tensor)?;
+        let deserialize_timer = trace.child_timer(
+            TraceLabels::new("frontend", "frontend.deserialize")
+                .path("fallback_controller")
+                .num_tokens(expert_ids.len()),
+        );
+        let deserialize_span = deserialize_timer.span();
+        let result = async { deserialize_safetensor_2_tch_tensor(&output_tensor) }
+            .instrument(deserialize_span)
+            .await?;
+        drop(deserialize_timer);
 
         info!("[Client] Controller fallback completed successfully");
 
@@ -519,8 +760,14 @@ impl ExpertKitClient {
         expert_ids: Vec<Vec<String>>,
         hidden_state: Tensor,
     ) -> Result<Tensor> {
+        let batch_size = hidden_state.size()[0] as usize;
+        let hidden_dim = hidden_state.size()[1] as usize;
+        let trace = ForwardTrace::start(&expert_ids, batch_size, hidden_dim, "direct_or_fallback");
         // Try direct worker path first (it already has retry logic)
-        match self.forward_expert_tensor(expert_ids.clone(), hidden_state.shallow_clone()).await {
+        match self
+            .forward_expert_tensor_direct(expert_ids.clone(), hidden_state.shallow_clone(), &trace)
+            .await
+        {
             Ok(result) => Ok(result),
             Err(e) => {
                 warn!(
@@ -537,16 +784,16 @@ impl ExpertKitClient {
                 }
 
                 // Fallback to controller as last resort
-                match self.forward_via_controller(&expert_ids, &hidden_state).await {
+                match self
+                    .forward_via_controller(&expert_ids, &hidden_state, &trace)
+                    .await
+                {
                     Ok(result) => {
                         info!("[Client] Controller fallback succeeded");
                         Ok(result)
                     }
                     Err(fallback_err) => {
-                        error!(
-                            "[Client] Controller fallback also failed: {}",
-                            fallback_err
-                        );
+                        error!("[Client] Controller fallback also failed: {}", fallback_err);
                         Err(anyhow::anyhow!(
                             "All paths failed. Direct: {}. Controller: {}",
                             e,

--- a/ek-integration/expertkit-transport-rs/src/lib.rs
+++ b/ek-integration/expertkit-transport-rs/src/lib.rs
@@ -6,6 +6,7 @@ use pyo3::prelude::*;
 
 mod client;
 mod lb;
+mod observability;
 mod python;
 mod routing;
 mod transport;

--- a/ek-integration/expertkit-transport-rs/src/observability.rs
+++ b/ek-integration/expertkit-transport-rs/src/observability.rs
@@ -1,0 +1,248 @@
+use std::{
+    sync::{
+        Once,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Instant,
+};
+
+use opentelemetry::propagation::Injector;
+use opentelemetry::{
+    KeyValue, propagation::TextMapCompositePropagator, trace::TracerProvider as _,
+};
+use opentelemetry_sdk::{
+    Resource,
+    propagation::{BaggagePropagator, TraceContextPropagator},
+    trace::{RandomIdGenerator, Sampler, SdkTracerProvider},
+};
+use opentelemetry_semantic_conventions::{
+    SCHEMA_URL,
+    resource::{DEPLOYMENT_ENVIRONMENT_NAME, SERVICE_VERSION},
+};
+use tonic::metadata::MetadataMap;
+use tracing::{Level, Span};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+static INIT: Once = Once::new();
+static REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+static EXPERT_CALL_ID: AtomicU64 = AtomicU64::new(1);
+static LAYER_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Clone)]
+pub struct TraceLabels {
+    pub component: &'static str,
+    pub stage: &'static str,
+    pub path: &'static str,
+    pub request_id: u64,
+    pub layer_id: u64,
+    pub expert_call_id: u64,
+    pub expert_id: String,
+    pub worker: String,
+    pub num_tokens: usize,
+}
+
+impl TraceLabels {
+    pub fn new(component: &'static str, stage: &'static str) -> Self {
+        Self {
+            component,
+            stage,
+            path: "unknown",
+            request_id: 0,
+            layer_id: 0,
+            expert_call_id: 0,
+            expert_id: String::new(),
+            worker: String::new(),
+            num_tokens: 0,
+        }
+    }
+
+    pub fn path(mut self, path: &'static str) -> Self {
+        self.path = path;
+        self
+    }
+
+    pub fn request_id(mut self, request_id: u64) -> Self {
+        self.request_id = request_id;
+        self
+    }
+
+    pub fn layer_id(mut self, layer_id: u64) -> Self {
+        self.layer_id = layer_id;
+        self
+    }
+
+    pub fn expert_call_id(mut self, expert_call_id: u64) -> Self {
+        self.expert_call_id = expert_call_id;
+        self
+    }
+
+    pub fn expert_id(mut self, expert_id: impl Into<String>) -> Self {
+        self.expert_id = expert_id.into();
+        self
+    }
+
+    pub fn worker(mut self, worker: impl Into<String>) -> Self {
+        self.worker = worker.into();
+        self
+    }
+
+    pub fn num_tokens(mut self, num_tokens: usize) -> Self {
+        self.num_tokens = num_tokens;
+        self
+    }
+}
+
+pub struct StageTimer {
+    labels: TraceLabels,
+    start: Instant,
+    span: Span,
+}
+
+impl StageTimer {
+    pub fn start(labels: TraceLabels) -> Self {
+        let span = trace_span(&labels);
+        Self {
+            labels,
+            start: Instant::now(),
+            span,
+        }
+    }
+
+    pub fn span(&self) -> Span {
+        self.span.clone()
+    }
+}
+
+impl Drop for StageTimer {
+    fn drop(&mut self) {
+        let elapsed_us = self.start.elapsed().as_micros() as u64;
+        let labels = &self.labels;
+        self.span.in_scope(|| {
+            tracing::info!(
+                elapsed_us,
+                component = labels.component,
+                stage = labels.stage,
+                path = labels.path,
+                request_id = labels.request_id,
+                layer_id = labels.layer_id,
+                expert_call_id = labels.expert_call_id,
+                expert_id = labels.expert_id.as_str(),
+                worker = labels.worker.as_str(),
+                num_tokens = labels.num_tokens,
+                "expert-kit trace stage done",
+            );
+        });
+    }
+}
+
+pub fn init_tracing() {
+    INIT.call_once(|| {
+        let exporter = match opentelemetry_otlp::SpanExporter::builder()
+            .with_tonic()
+            .build()
+        {
+            Ok(exporter) => exporter,
+            Err(err) => {
+                log::warn!("[Tracing] failed to initialize OTLP exporter: {err}");
+                return;
+            }
+        };
+
+        let resource = Resource::builder()
+            .with_service_name("frontend")
+            .with_schema_url(
+                [
+                    KeyValue::new(SERVICE_VERSION, env!("CARGO_PKG_VERSION")),
+                    KeyValue::new(DEPLOYMENT_ENVIRONMENT_NAME, "develop"),
+                ],
+                SCHEMA_URL,
+            )
+            .build();
+        let provider = SdkTracerProvider::builder()
+            .with_sampler(Sampler::AlwaysOn)
+            .with_id_generator(RandomIdGenerator::default())
+            .with_resource(resource)
+            .with_batch_exporter(exporter)
+            .build();
+        let tracer = provider.tracer("expertkit-transport-rs");
+        let propagator = TextMapCompositePropagator::new(vec![
+            Box::new(BaggagePropagator::new()),
+            Box::new(TraceContextPropagator::new()),
+        ]);
+        opentelemetry::global::set_text_map_propagator(propagator);
+
+        if tracing_subscriber::registry()
+            .with(tracing_subscriber::filter::LevelFilter::from_level(
+                Level::INFO,
+            ))
+            .with(tracing_opentelemetry::layer().with_tracer(tracer))
+            .try_init()
+            .is_err()
+        {
+            log::debug!("[Tracing] tracing subscriber already initialized");
+        }
+    });
+}
+
+pub fn next_request_id() -> u64 {
+    REQUEST_ID.fetch_add(1, Ordering::SeqCst)
+}
+
+pub fn next_expert_call_id() -> u64 {
+    EXPERT_CALL_ID.fetch_add(1, Ordering::SeqCst)
+}
+
+pub fn next_layer_id() -> u64 {
+    LAYER_ID.fetch_add(1, Ordering::SeqCst)
+}
+
+pub fn trace_span(labels: &TraceLabels) -> Span {
+    tracing::span!(
+        Level::INFO,
+        "ek.trace",
+        otel.name = labels.stage,
+        component = labels.component,
+        stage = labels.stage,
+        path = labels.path,
+        request_id = labels.request_id,
+        layer_id = labels.layer_id,
+        expert_call_id = labels.expert_call_id,
+        expert_id = labels.expert_id.as_str(),
+        worker = labels.worker.as_str(),
+        num_tokens = labels.num_tokens,
+    )
+}
+
+pub fn inject_current_trace_context(metadata: &mut MetadataMap) {
+    let ctx = Span::current().context();
+    let mut injector = MetadataInjector(metadata);
+    opentelemetry::global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(&ctx, &mut injector);
+    });
+}
+
+pub fn infer_layer_id(expert_ids: &[Vec<String>], fallback: u64) -> u64 {
+    expert_ids
+        .iter()
+        .flatten()
+        .find_map(|expert_id| {
+            let marker = expert_id.rfind("/l")?;
+            let after_layer = &expert_id[marker + 2..];
+            let end = after_layer.find("-e").unwrap_or(after_layer.len());
+            after_layer[..end].parse::<u64>().ok()
+        })
+        .unwrap_or(fallback)
+}
+
+struct MetadataInjector<'a>(&'a mut MetadataMap);
+
+impl Injector for MetadataInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        if let Ok(key) = tonic::metadata::MetadataKey::from_bytes(key.as_bytes())
+            && let Ok(value) = value.parse()
+        {
+            self.0.insert(key, value);
+        }
+    }
+}

--- a/ek-integration/expertkit-transport-rs/src/python/bindings.rs
+++ b/ek-integration/expertkit-transport-rs/src/python/bindings.rs
@@ -2,6 +2,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyAny;
 
 use crate::client::ExpertKitClient as RustExpertKitClient;
+use crate::observability::init_tracing;
 use crate::utils::{TensorMetadata, pytorch_to_tch_tensor, tch_to_pytorch_tensor};
 
 const DEFAULT_THREAD_NUM: usize = 16;
@@ -39,6 +40,10 @@ impl PyExpertKitClient {
                     e
                 ))
             })?;
+        {
+            let _entered = runtime.enter();
+            init_tracing();
+        }
 
         Ok(Self {
             client: Some(RustExpertKitClient::new(controller_addr, timeout)),
@@ -109,7 +114,9 @@ impl PyExpertKitClient {
                 .block_on(async {
                     if use_fallback {
                         // Use fallback version for maximum resilience
-                        client.forward_expert_tensor_with_fallback(expert_ids, input_tensor).await
+                        client
+                            .forward_expert_tensor_with_fallback(expert_ids, input_tensor)
+                            .await
                     } else {
                         // Direct path only (still has retry logic)
                         client.forward_expert_tensor(expert_ids, input_tensor).await

--- a/ek-integration/expertkit-transport-rs/src/transport/grpc.rs
+++ b/ek-integration/expertkit-transport-rs/src/transport/grpc.rs
@@ -29,6 +29,8 @@ pub mod proto {
 
 use proto::ek::worker::v1::{ForwardReq, computation_service_client::ComputationServiceClient};
 
+use crate::observability::inject_current_trace_context;
+
 /// Connect timeout for establishing new gRPC connections (3 seconds)
 const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 
@@ -92,7 +94,10 @@ impl GrpcTransport {
     async fn invalidate_channel(&self, endpoint: &str) {
         let mut channels = self.channels.write().await;
         if channels.remove(endpoint).is_some() {
-            warn!("[GrpcTransport] Invalidated cached channel for {}", endpoint);
+            warn!(
+                "[GrpcTransport] Invalidated cached channel for {}",
+                endpoint
+            );
         }
     }
 }
@@ -148,6 +153,8 @@ impl Transport for GrpcTransport {
             );
 
             // Send with timeout
+            let mut grpc_req = tonic::Request::new(grpc_req);
+            inject_current_trace_context(grpc_req.metadata_mut());
             let result = tokio::time::timeout(self.timeout, client.forward(grpc_req)).await;
 
             match result {

--- a/ek-integration/expertkit-transport-rs/src/transport/mod.rs
+++ b/ek-integration/expertkit-transport-rs/src/transport/mod.rs
@@ -25,6 +25,9 @@ pub struct ExpertRequest {
     pub expert_id: String,
     pub tensor_data: Vec<u8>, // Safetensors blob containing batched sequences
     pub num_sequences: usize, // Number of sequences in this batch
+    pub request_id: u64,
+    pub layer_id: u64,
+    pub expert_call_id: u64,
 }
 
 impl ExpertRequest {
@@ -34,7 +37,22 @@ impl ExpertRequest {
             expert_id,
             tensor_data,
             num_sequences,
+            request_id: 0,
+            layer_id: 0,
+            expert_call_id: 0,
         }
+    }
+
+    pub fn with_trace_context(
+        mut self,
+        request_id: u64,
+        layer_id: u64,
+        expert_call_id: u64,
+    ) -> Self {
+        self.request_id = request_id;
+        self.layer_id = layer_id;
+        self.expert_call_id = expert_call_id;
+        self
     }
 }
 


### PR DESCRIPTION
Depends on #132 

## Summary
This PR adds worker-side tracing spans for MoE expert execution.

## Changes

- Add `worker.forward` span for each worker expert request.
- Add `worker.queue_wait` span around blocking worker task scheduling.
- Add `worker.load_expert` span for expert lookup/loading.
- Add `worker.deserialize` span for request tensor deserialization.
- Add `worker.compute` span for expert computation.
- Add `worker.serialize` span for response tensor serialization.
- Propagate frontend trace context so worker spans attach under `frontend.send_worker`.

<img width="1652" height="352" alt="image" src="https://github.com/user-attachments/assets/32a1fa67-809a-4342-88bc-6ecc7640c87f" />
<img width="1675" height="494" alt="image" src="https://github.com/user-attachments/assets/3f3970dd-b1e3-4d98-989b-eb3028c76708" />

Related to #131