### PR TITLE
Add controller tracing spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,6 +1495,7 @@ dependencies = [
  "ndarray",
  "ndarray-rand",
  "nix 0.30.1",
+ "opentelemetry",
  "ort",
  "ort-sys",
  "prometheus",
@@ -1630,6 +1631,10 @@ dependencies = [
  "log",
  "ndarray",
  "nix 0.29.0",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
  "parking_lot",
  "prost 0.12.6",
  "pyo3",
@@ -1644,6 +1649,9 @@ dependencies = [
  "tonic 0.11.0",
  "tonic-build 0.11.0",
  "tower 0.4.13",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/ek-computation/Cargo.toml
+++ b/ek-computation/Cargo.toml
@@ -45,6 +45,7 @@ tonic = { workspace = true }
 tower = { workspace = true }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
+opentelemetry = { workspace = true }
 url = { workspace = true }
 
 [build-dependencies]

--- a/ek-computation/src/controller/executor.rs
+++ b/ek-computation/src/controller/executor.rs
@@ -16,12 +16,13 @@ use tokio::{
     sync::{Mutex, mpsc},
     task::JoinHandle,
 };
-use tracing::{Instrument, instrument, span};
+use tracing::{Instrument, Span, span};
 
 use crate::{
     backend::{EkTensor, torch::TchTensor},
     controller::registry::{ExpertClient, ExpertId, ExpertIdRef, ShmqWorkerReq, ShmqWorkerResp},
     metrics::METRIC_CONTROLLER_INTRA_REQ,
+    observability::{StageTimer, TraceLabels, inject_current_trace_context, next_expert_call_id},
     proto::ek::worker::v1::{self},
 };
 
@@ -276,78 +277,141 @@ impl NaiveExecutor {
         self.pending_egress.retain(|_, metas| !metas.is_empty());
     }
 
-    #[instrument]
     pub async fn inner_execute(&mut self) -> EKResult<()> {
         let mut tit = PerfTimer::new("inner_execute");
         let mut handles: Vec<JoinHandle<Result<ForwardResponse, ExpertError>>> = vec![];
-        let mut chips: Vec<(ExpertId, Vec<EgressMeta>)> = vec![];
+        let mut chips: Vec<(ExpertId, Vec<EgressMeta>, StageTimer, Span)> = vec![];
         let settings = get_ek_settings();
 
         while let Some((expert_id, egress_meta)) = self.pending_egress.pop_first() {
             let expert_id: ExpertIdRef = expert_id.as_ref();
+            let expert_call_id = next_expert_call_id();
+            let num_tokens = egress_meta.len();
+            let expert_timer = StageTimer::start(
+                TraceLabels::new("controller", "controller.expert_call")
+                    .path("fallback_controller")
+                    .expert_call_id(expert_call_id)
+                    .expert_id(expert_id)
+                    .num_tokens(num_tokens),
+            );
+            let expert_span = expert_timer.span();
 
             // Retry selecting a worker — the expert may be in recovery
             // (recently assigned to a surviving worker but not yet loaded).
             // Wait up to ~62 s for it to become available before giving up.
             const MAX_ATTEMPTS: u32 = 6;
             let client = {
-                let mut last_err = None;
-                let mut found = None;
-                for attempt in 0..MAX_ATTEMPTS {
-                    match self.registry.lock().await.select(expert_id).await {
-                        Ok(c) => {
-                            if attempt > 0 {
-                                log::info!(
-                                    "controller executor: worker found for {expert_id} on attempt {}",
-                                    attempt + 1
-                                );
+                let schedule_timer = {
+                    let _entered = expert_span.enter();
+                    StageTimer::start(
+                        TraceLabels::new("controller", "controller.schedule")
+                            .path("fallback_controller")
+                            .expert_call_id(expert_call_id)
+                            .expert_id(expert_id)
+                            .num_tokens(num_tokens),
+                    )
+                };
+                let schedule_span = schedule_timer.span();
+                let selected = async {
+                    let mut last_err = None;
+                    let mut found = None;
+                    for attempt in 0..MAX_ATTEMPTS {
+                        match self.registry.lock().await.select(expert_id).await {
+                            Ok(c) => {
+                                if attempt > 0 {
+                                    log::info!(
+                                        "controller executor: worker found for {expert_id} on attempt {}",
+                                        attempt + 1
+                                    );
+                                }
+                                found = Some(c);
+                                break;
                             }
-                            found = Some(c);
-                            break;
-                        }
-                        Err(e) => {
-                            let backoff = std::time::Duration::from_secs(1u64 << attempt.min(4));
-                            log::info!(
-                                "controller executor: no worker for {expert_id} \
-                                 (attempt {}/{MAX_ATTEMPTS}), retrying in {:?}: {e}",
-                                attempt + 1,
-                                backoff
-                            );
-                            last_err = Some(e);
-                            tokio::time::sleep(backoff).await;
+                            Err(e) => {
+                                let backoff =
+                                    std::time::Duration::from_secs(1u64 << attempt.min(4));
+                                log::info!(
+                                    "controller executor: no worker for {expert_id} \
+                                     (attempt {}/{MAX_ATTEMPTS}), retrying in {:?}: {e}",
+                                    attempt + 1,
+                                    backoff
+                                );
+                                last_err = Some(e);
+                                tokio::time::sleep(backoff).await;
+                            }
                         }
                     }
-                }
-                match found {
-                    Some(c) => c,
-                    None => {
-                        let err = ExpertError::NoWorker {
-                            expert_id: expert_id.to_owned(),
-                            message: format!(
-                                "no worker after {MAX_ATTEMPTS} attempts: {last_err:?}"
-                            ),
-                        };
-                        log::error!("controller executor: {err}");
-                        self.mark_egress_failed(&egress_meta, err.clone())?;
-                        for handle in handles {
-                            handle.abort();
+                    match found {
+                        Some(c) => Ok(c),
+                        None => {
+                            let err = ExpertError::NoWorker {
+                                expert_id: expert_id.to_owned(),
+                                message: format!(
+                                    "no worker after {MAX_ATTEMPTS} attempts: {last_err:?}"
+                                ),
+                            };
+                            log::error!("controller executor: {err}");
+                            self.mark_egress_failed(&egress_meta, err.clone())?;
+                            for handle in handles.iter() {
+                                handle.abort();
+                            }
+                            self.cleanup_egress_requests(&egress_meta);
+                            Err(EKError::NotFound(err.to_string()))
                         }
-                        self.cleanup_egress_requests(&egress_meta);
-                        return Err(EKError::NotFound(err.to_string()));
                     }
-                }
+                };
+                let selected = selected.instrument(schedule_span).await;
+                drop(schedule_timer);
+                selected?
             };
             self.mark_egress_running(&egress_meta)?;
-            chips.push((expert_id.to_owned(), egress_meta.to_owned()));
+            chips.push((
+                expert_id.to_owned(),
+                egress_meta.to_owned(),
+                expert_timer,
+                expert_span.clone(),
+            ));
 
             let seq_gids = egress_meta
                 .iter()
                 .map(|e| e.seq_gid)
                 .collect::<Vec<GlobalSeqId>>();
 
-            let egress_tensor = self.assemble_seq_tensors(seq_gids)?;
+            let egress_tensor = {
+                let timer = {
+                    let _entered = expert_span.enter();
+                    StageTimer::start(
+                        TraceLabels::new("controller", "controller.assemble")
+                            .path("fallback_controller")
+                            .expert_call_id(expert_call_id)
+                            .expert_id(expert_id)
+                            .num_tokens(num_tokens),
+                    )
+                };
+                let span = timer.span();
+                let _entered = span.enter();
+                let tensor = self.assemble_seq_tensors(seq_gids)?;
+                drop(timer);
+                tensor
+            };
             log::debug!("egress tensor shape={:?}", egress_tensor.size());
-            let serialized_tensor = TchTensor::from(egress_tensor).serialize();
+            let serialized_tensor = {
+                let timer = {
+                    let _entered = expert_span.enter();
+                    StageTimer::start(
+                        TraceLabels::new("controller", "controller.serialize")
+                            .path("fallback_controller")
+                            .expert_call_id(expert_call_id)
+                            .expert_id(expert_id)
+                            .num_tokens(num_tokens),
+                    )
+                };
+                let span = timer.span();
+                let _entered = span.enter();
+                let tensor = TchTensor::from(egress_tensor).serialize();
+                drop(timer);
+                tensor
+            };
             let seqs = egress_meta
                 .iter()
                 .map(|_e| v1::forward_req::SequenceInfo {
@@ -372,6 +436,14 @@ impl NaiveExecutor {
                                 tensor: serialized_tensor,
                                 sequences: seqs,
                             };
+                            let send_timer = StageTimer::start(
+                                TraceLabels::new("controller", "controller.send_worker")
+                                    .path("fallback_controller")
+                                    .expert_call_id(expert_call_id)
+                                    .expert_id(expert_id.as_str())
+                                    .num_tokens(num_tokens),
+                            );
+                            let send_span = send_timer.span();
 
                             let start = time::Instant::now();
                             let _d = Defers::defer(Box::new(move || {
@@ -381,19 +453,26 @@ impl NaiveExecutor {
                                     .with_label_values(&[settings.inference.model_name.as_str()])
                                     .observe(elapsed.as_micros() as f64);
                             }));
-                            cli.forward(req)
-                                .await
-                                .map(|resp| ForwardResponse::Grpc(resp.into_inner()))
-                                .map_err(|e| {
-                                    let message = format!("gRPC forward error: {e}");
-                                    if e.code() == tonic::Code::Internal {
-                                        ExpertError::Compute { expert_id, message }
-                                    } else {
-                                        ExpertError::Transport { expert_id, message }
-                                    }
-                                })
+                            let result = async {
+                                let mut req = tonic::Request::new(req);
+                                inject_current_trace_context(req.metadata_mut());
+                                cli.forward(req).await
+                            }
+                            .instrument(send_span)
+                            .await
+                            .map(|resp| ForwardResponse::Grpc(resp.into_inner()))
+                            .map_err(|e| {
+                                let message = format!("gRPC forward error: {e}");
+                                if e.code() == tonic::Code::Internal {
+                                    ExpertError::Compute { expert_id, message }
+                                } else {
+                                    ExpertError::Transport { expert_id, message }
+                                }
+                            });
+                            drop(send_timer);
+                            result
                         }
-                        .in_current_span(),
+                        .instrument(expert_span.clone()),
                     );
                     handles.push(f);
                 }
@@ -514,7 +593,9 @@ impl NaiveExecutor {
         tit.stop("egress_req_sent");
 
         for (egress_idx, handle) in handles.into_iter().enumerate() {
-            let egress = chips[egress_idx].clone();
+            let (expert_id_for_chip, egress_meta_for_chip, _expert_timer, expert_span) =
+                &chips[egress_idx];
+            let egress = (expert_id_for_chip.clone(), egress_meta_for_chip.clone());
             let res = match handle.await {
                 Ok(Ok(res)) => res,
                 Ok(Err(err)) => {
@@ -532,16 +613,31 @@ impl NaiveExecutor {
                     return Err(EKError::RuntimeError(err.to_string()));
                 }
             };
-            let res_safetensor = match SafeTensors::deserialize(res.output_tensor()) {
-                Ok(res) => res,
-                Err(e) => {
-                    let err = ExpertError::Compute {
-                        expert_id: egress.0.clone(),
-                        message: format!("invalid output tensor: {e}"),
-                    };
-                    self.mark_egress_failed(&egress.1, err.clone())?;
-                    self.cleanup_egress_requests(&egress.1);
-                    return Err(EKError::RuntimeError(err.to_string()));
+            let res_safetensor = {
+                let timer = {
+                    let _entered = expert_span.enter();
+                    StageTimer::start(
+                        TraceLabels::new("controller", "controller.deserialize")
+                            .path("fallback_controller")
+                            .expert_id(egress.0.as_str())
+                            .num_tokens(egress.1.len()),
+                    )
+                };
+                let span = timer.span();
+                let _entered = span.enter();
+                let parsed = SafeTensors::deserialize(res.output_tensor());
+                drop(timer);
+                match parsed {
+                    Ok(res) => res,
+                    Err(e) => {
+                        let err = ExpertError::Compute {
+                            expert_id: egress.0.clone(),
+                            message: format!("invalid output tensor: {e}"),
+                        };
+                        self.mark_egress_failed(&egress.1, err.clone())?;
+                        self.cleanup_egress_requests(&egress.1);
+                        return Err(EKError::RuntimeError(err.to_string()));
+                    }
                 }
             };
             // TODO: hardcode safe tensor name
@@ -557,7 +653,22 @@ impl NaiveExecutor {
                     return Err(EKError::RuntimeError(err.to_string()));
                 }
             };
-            let res_tensor = TchTensor::from(&view).inner();
+            let res_tensor = {
+                let timer = {
+                    let _entered = expert_span.enter();
+                    StageTimer::start(
+                        TraceLabels::new("controller", "controller.merge")
+                            .path("fallback_controller")
+                            .expert_id(egress.0.as_str())
+                            .num_tokens(egress.1.len()),
+                    )
+                };
+                let span = timer.span();
+                let _entered = span.enter();
+                let tensor = TchTensor::from(&view).inner();
+                drop(timer);
+                tensor
+            };
 
             log::debug!("received tensor shape={:?}", res_tensor.size());
             for (seq_idx, egress_meta) in egress.1.iter().enumerate() {
@@ -656,7 +767,6 @@ impl NaiveExecutor {
         Ok(())
     }
 
-    #[instrument(skip(self, req))]
     fn break_down_to_egress(&mut self, req: &v1::ForwardReq, req_id: ReqId) {
         for (idx, seq) in req.sequences.iter().enumerate() {
             // update pending_seq

--- a/ek-computation/src/controller/mod.rs
+++ b/ek-computation/src/controller/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     state::io::StateReaderImpl,
 };
 use ek_base::error::EKResult;
+use ek_base::tracing::grpc::OTelGrpcServerMiddleware;
 use metrics::spawn_metrics_server;
 use service::control::PlanServiceImpl;
 use std::sync::Arc;
@@ -48,8 +49,7 @@ pub async fn controller_main() -> EKResult<()> {
 
     let state_srv = tokio::task::spawn(async move {
         let srv = controller::service::state::StateServerImpl::new();
-        let routing_srv =
-            controller::service::routing::RoutingServiceImpl::new(broadcaster_intra);
+        let routing_srv = controller::service::routing::RoutingServiceImpl::new(broadcaster_intra);
         let intra_addr = format!(
             "{}:{}",
             settings.controller.listen, settings.controller.ports.intra
@@ -76,16 +76,15 @@ pub async fn controller_main() -> EKResult<()> {
         .parse()
         .unwrap();
 
-        // let layer = tower::ServiceBuilder::new()
-        //     .layer_fn(OTelGrpcServerMiddleware::new)
-        //     .into_inner();
+        let layer = tower::ServiceBuilder::new()
+            .layer_fn(OTelGrpcServerMiddleware::new)
+            .into_inner();
 
         log::info!("computation server listening on {inter_addr}");
         let plan_srv = PlanServiceImpl::new();
-        let routing_srv =
-            controller::service::routing::RoutingServiceImpl::new(broadcaster_clone);
+        let routing_srv = controller::service::routing::RoutingServiceImpl::new(broadcaster_clone);
         let err = tonic::transport::Server::builder()
-            // .layer(layer)
+            .layer(layer)
             .add_service(
                 ComputationServiceServer::new(srv)
                     .max_decoding_message_size(1024 * 1024 * 1024)

--- a/ek-computation/src/controller/registry.rs
+++ b/ek-computation/src/controller/registry.rs
@@ -1,14 +1,14 @@
 use std::{
     collections::HashMap,
     sync::{
-        atomic::{AtomicUsize, Ordering},
         Arc, OnceLock,
+        atomic::{AtomicUsize, Ordering},
     },
     time::Duration,
 };
 
 use crate::{
-    shmq::{rdma_impl::RdmaQueue, GeneralShmQueueBytes, RdmaEndpointClient, ShmQueue},
+    shmq::{GeneralShmQueueBytes, RdmaEndpointClient, ShmQueue, rdma_impl::RdmaQueue},
     state::io::StateReaderImpl,
 };
 use ek_base::{

--- a/ek-computation/src/controller/service/compute.rs
+++ b/ek-computation/src/controller/service/compute.rs
@@ -9,6 +9,7 @@ use crate::{
         executor::{Executor, get_executor},
         metrics::METRIC_CONTROLLER_LAYER,
     },
+    observability::{StageTimer, TraceLabels, child_span_from_traceparent, extract_traceparent},
     proto::ek::worker::v1::{self, computation_service_server::ComputationService},
 };
 
@@ -32,11 +33,6 @@ impl ComputationService for ComputationProxyServiceImpl {
 }
 
 impl ComputationProxyServiceImpl {
-    #[tracing::instrument(
-        skip(self, request),
-        level = "info",
-        fields(method = "ComputationProxyServiceImpl::forward",)
-    )]
     async fn inner_controller_forward(
         &self,
         request: tonic::Request<v1::ForwardReq>,
@@ -45,6 +41,12 @@ impl ComputationProxyServiceImpl {
         log::info!(seq_len; "forward request in controller start");
         let start = std::time::Instant::now();
         let settings = get_ek_settings();
+        let traceparent = extract_traceparent(request.metadata());
+        let forward_labels = TraceLabels::new("controller", "controller.forward")
+            .path("fallback_controller")
+            .num_tokens(seq_len);
+        let forward_span = child_span_from_traceparent(&forward_labels, traceparent.as_str());
+        let _forward_timer = StageTimer::start_with_span(forward_labels, forward_span.clone());
 
         let cloned_start = start;
         let _d = Defers::defer(Box::new(move || {
@@ -55,10 +57,22 @@ impl ComputationProxyServiceImpl {
                 .observe(elapsed.as_micros() as f64);
         }));
 
-        let mut rx = {
-            let mut lg = self.executor.lock().await;
-            lg.submit(request.get_ref()).await?
+        let submit_timer = {
+            let _entered = forward_span.enter();
+            StageTimer::start(
+                TraceLabels::new("controller", "controller.submit")
+                    .path("fallback_controller")
+                    .num_tokens(seq_len),
+            )
         };
+        let submit_span = submit_timer.span();
+        let mut rx = async {
+            let mut lg = self.executor.lock().await;
+            lg.submit(request.get_ref()).await
+        }
+        .instrument(submit_span)
+        .await?;
+        drop(submit_timer);
 
         let exec_bg = self.executor.clone();
         let (err_tx, mut err_rx) = mpsc::channel(1);
@@ -72,18 +86,28 @@ impl ComputationProxyServiceImpl {
                     err_tx.send(err).await.unwrap();
                 }
             }
-            .in_current_span(),
+            .instrument(forward_span.clone()),
         );
 
+        let wait_timer = {
+            let _entered = forward_span.enter();
+            StageTimer::start(
+                TraceLabels::new("controller", "controller.wait_result")
+                    .path("fallback_controller")
+                    .num_tokens(seq_len),
+            )
+        };
+        let wait_span = wait_timer.span();
         tokio::select! {
-            err = err_rx.recv() => {
+            err = err_rx.recv().instrument(wait_span.clone()) => {
                 if let Some(err) = err {
                     log::error!("executor error: {err:?}");
                     return Err(tonic::Status::internal(format!("executor error: {err:?}")));
                 }
                 // err_tx dropped: exec task completed without error, wait for result
             }
-            res = rx.recv() => {
+            res = rx.recv().instrument(wait_span) => {
+                drop(wait_timer);
                 let elapsed_ms = start.elapsed().as_millis();
                 log::info!(elapsed_ms; "forward request in controller done");
                 if let Some(resp) = res {
@@ -93,6 +117,7 @@ impl ComputationProxyServiceImpl {
                 }
             }
         }
+        drop(wait_timer);
         let elapsed_ms = start.elapsed().as_millis();
         log::info!(elapsed_ms; "forward request in controller done");
         match rx.recv().await {

--- a/ek-computation/src/lib.rs
+++ b/ek-computation/src/lib.rs
@@ -2,6 +2,7 @@ pub mod backend;
 pub mod controller;
 pub mod ffn;
 pub mod metrics;
+pub mod observability;
 pub mod onnx;
 pub mod proto;
 mod schema;

--- a/ek-computation/src/observability.rs
+++ b/ek-computation/src/observability.rs
@@ -1,0 +1,203 @@
+use std::{
+    collections::HashMap,
+    sync::atomic::{AtomicU64, Ordering},
+    time::Instant,
+};
+
+use opentelemetry::propagation::{Extractor, Injector};
+use tonic::metadata::MetadataMap;
+use tracing::{Level, Span};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+static REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+static EXPERT_CALL_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Clone)]
+pub struct TraceLabels {
+    pub component: &'static str,
+    pub stage: &'static str,
+    pub path: &'static str,
+    pub request_id: u64,
+    pub layer_id: u64,
+    pub expert_call_id: u64,
+    pub expert_id: String,
+    pub worker: String,
+    pub num_tokens: usize,
+}
+
+impl TraceLabels {
+    pub fn new(component: &'static str, stage: &'static str) -> Self {
+        Self {
+            component,
+            stage,
+            path: "unknown",
+            request_id: 0,
+            layer_id: 0,
+            expert_call_id: 0,
+            expert_id: String::new(),
+            worker: String::new(),
+            num_tokens: 0,
+        }
+    }
+
+    pub fn path(mut self, path: &'static str) -> Self {
+        self.path = path;
+        self
+    }
+
+    pub fn request_id(mut self, request_id: u64) -> Self {
+        self.request_id = request_id;
+        self
+    }
+
+    pub fn layer_id(mut self, layer_id: u64) -> Self {
+        self.layer_id = layer_id;
+        self
+    }
+
+    pub fn expert_call_id(mut self, expert_call_id: u64) -> Self {
+        self.expert_call_id = expert_call_id;
+        self
+    }
+
+    pub fn expert_id(mut self, expert_id: impl Into<String>) -> Self {
+        self.expert_id = expert_id.into();
+        self
+    }
+
+    pub fn worker(mut self, worker: impl Into<String>) -> Self {
+        self.worker = worker.into();
+        self
+    }
+
+    pub fn num_tokens(mut self, num_tokens: usize) -> Self {
+        self.num_tokens = num_tokens;
+        self
+    }
+}
+
+pub struct StageTimer {
+    labels: TraceLabels,
+    start: Instant,
+    span: Span,
+}
+
+impl StageTimer {
+    pub fn start(labels: TraceLabels) -> Self {
+        let span = trace_span(&labels);
+        Self::start_with_span(labels, span)
+    }
+
+    pub fn start_with_span(labels: TraceLabels, span: Span) -> Self {
+        Self {
+            labels,
+            start: Instant::now(),
+            span,
+        }
+    }
+
+    pub fn span(&self) -> Span {
+        self.span.clone()
+    }
+}
+
+impl Drop for StageTimer {
+    fn drop(&mut self) {
+        let elapsed_us = self.start.elapsed().as_micros() as u64;
+        let labels = &self.labels;
+        self.span.in_scope(|| {
+            tracing::info!(
+                elapsed_us,
+                component = labels.component,
+                stage = labels.stage,
+                path = labels.path,
+                request_id = labels.request_id,
+                layer_id = labels.layer_id,
+                expert_call_id = labels.expert_call_id,
+                expert_id = labels.expert_id.as_str(),
+                worker = labels.worker.as_str(),
+                num_tokens = labels.num_tokens,
+                "expert-kit trace stage done",
+            );
+        });
+    }
+}
+
+pub fn next_request_id() -> u64 {
+    REQUEST_ID.fetch_add(1, Ordering::SeqCst)
+}
+
+pub fn next_expert_call_id() -> u64 {
+    EXPERT_CALL_ID.fetch_add(1, Ordering::SeqCst)
+}
+
+pub fn trace_span(labels: &TraceLabels) -> Span {
+    tracing::span!(
+        Level::INFO,
+        "ek.trace",
+        otel.name = labels.stage,
+        component = labels.component,
+        stage = labels.stage,
+        path = labels.path,
+        request_id = labels.request_id,
+        layer_id = labels.layer_id,
+        expert_call_id = labels.expert_call_id,
+        expert_id = labels.expert_id.as_str(),
+        worker = labels.worker.as_str(),
+        num_tokens = labels.num_tokens,
+    )
+}
+
+pub fn child_span_from_traceparent(labels: &TraceLabels, traceparent: &str) -> Span {
+    let span = trace_span(labels);
+    if !traceparent.is_empty() {
+        let mut headers = HashMap::new();
+        headers.insert("traceparent".to_string(), traceparent.to_string());
+        let extractor = StringMapExtractor(headers);
+        let ctx = opentelemetry::global::get_text_map_propagator(|propagator| {
+            propagator.extract(&extractor)
+        });
+        span.set_parent(ctx);
+    }
+    span
+}
+
+pub fn extract_traceparent(metadata: &MetadataMap) -> String {
+    metadata
+        .get("traceparent")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_string()
+}
+
+pub fn inject_current_trace_context(metadata: &mut MetadataMap) {
+    let ctx = Span::current().context();
+    let mut injector = MetadataInjector(metadata);
+    opentelemetry::global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(&ctx, &mut injector);
+    });
+}
+
+struct MetadataInjector<'a>(&'a mut MetadataMap);
+
+impl Injector for MetadataInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        if let Ok(key) = tonic::metadata::MetadataKey::from_bytes(key.as_bytes())
+            && let Ok(value) = value.parse()
+        {
+            self.0.insert(key, value);
+        }
+    }
+}
+
+struct StringMapExtractor(HashMap<String, String>);
+
+impl Extractor for StringMapExtractor {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).map(String::as_str)
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(String::as_str).collect()
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds controller-side tracing spans for MoE forwarding, stacked on top of the frontend/transport and worker tracing PRs.

It instruments the fallback controller path so Jaeger can attribute latency across controller scheduling, request assembly, worker transport, result deserialization, and merge stages.

## Changes

- Add `controller.forward` as the top-level controller forwarding span.
- Add `controller.submit` and `controller.wait_result` spans around controller executor submission and result waiting.
- Add per-expert controller spans:
  - `controller.expert_call`
  - `controller.schedule`
  - `controller.assemble`
  - `controller.serialize`
  - `controller.send_worker`
  - `controller.deserialize`
  - `controller.merge`
- Propagate trace context from controller worker sends so worker spans attach under `controller.send_worker`.

<img width="1679" height="755" alt="image" src="https://github.com/user-attachments/assets/6aadbc91-9f9b-408f-a959-3664f59329de" />


Related to #131 





