### PR TITLE
Tracing flush

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,6 +1495,7 @@ dependencies = [
  "ndarray",
  "ndarray-rand",
  "nix 0.30.1",
+ "opentelemetry",
  "ort",
  "ort-sys",
  "prometheus",
@@ -1630,6 +1631,10 @@ dependencies = [
  "log",
  "ndarray",
  "nix 0.29.0",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
  "parking_lot",
  "prost 0.12.6",
  "pyo3",
@@ -1644,6 +1649,9 @@ dependencies = [
  "tonic 0.11.0",
  "tonic-build 0.11.0",
  "tower 0.4.13",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/ek-computation/Cargo.toml
+++ b/ek-computation/Cargo.toml
@@ -45,6 +45,7 @@ tonic = { workspace = true }
 tower = { workspace = true }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
+opentelemetry = { workspace = true }
 url = { workspace = true }
 
 [build-dependencies]

--- a/ek-computation/src/controller/executor.rs
+++ b/ek-computation/src/controller/executor.rs
@@ -16,12 +16,13 @@ use tokio::{
     sync::{Mutex, mpsc},
     task::JoinHandle,
 };
-use tracing::{Instrument, instrument, span};
+use tracing::{Instrument, Span, span};
 
 use crate::{
     backend::{EkTensor, torch::TchTensor},
     controller::registry::{ExpertClient, ExpertId, ExpertIdRef, ShmqWorkerReq, ShmqWorkerResp},
     metrics::METRIC_CONTROLLER_INTRA_REQ,
+    observability::{StageTimer, TraceLabels, inject_current_trace_context, next_expert_call_id},
     proto::ek::worker::v1::{self},
 };
 
@@ -276,78 +277,141 @@ impl NaiveExecutor {
         self.pending_egress.retain(|_, metas| !metas.is_empty());
     }
 
-    #[instrument]
     pub async fn inner_execute(&mut self) -> EKResult<()> {
         let mut tit = PerfTimer::new("inner_execute");
         let mut handles: Vec<JoinHandle<Result<ForwardResponse, ExpertError>>> = vec![];
-        let mut chips: Vec<(ExpertId, Vec<EgressMeta>)> = vec![];
+        let mut chips: Vec<(ExpertId, Vec<EgressMeta>, StageTimer, Span)> = vec![];
         let settings = get_ek_settings();
 
         while let Some((expert_id, egress_meta)) = self.pending_egress.pop_first() {
             let expert_id: ExpertIdRef = expert_id.as_ref();
+            let expert_call_id = next_expert_call_id();
+            let num_tokens = egress_meta.len();
+            let expert_timer = StageTimer::start(
+                TraceLabels::new("controller", "controller.expert_call")
+                    .path("fallback_controller")
+                    .expert_call_id(expert_call_id)
+                    .expert_id(expert_id)
+                    .num_tokens(num_tokens),
+            );
+            let expert_span = expert_timer.span();
 
             // Retry selecting a worker — the expert may be in recovery
             // (recently assigned to a surviving worker but not yet loaded).
             // Wait up to ~62 s for it to become available before giving up.
             const MAX_ATTEMPTS: u32 = 6;
             let client = {
-                let mut last_err = None;
-                let mut found = None;
-                for attempt in 0..MAX_ATTEMPTS {
-                    match self.registry.lock().await.select(expert_id).await {
-                        Ok(c) => {
-                            if attempt > 0 {
-                                log::info!(
-                                    "controller executor: worker found for {expert_id} on attempt {}",
-                                    attempt + 1
-                                );
+                let schedule_timer = {
+                    let _entered = expert_span.enter();
+                    StageTimer::start(
+                        TraceLabels::new("controller", "controller.schedule")
+                            .path("fallback_controller")
+                            .expert_call_id(expert_call_id)
+                            .expert_id(expert_id)
+                            .num_tokens(num_tokens),
+                    )
+                };
+                let schedule_span = schedule_timer.span();
+                let selected = async {
+                    let mut last_err = None;
+                    let mut found = None;
+                    for attempt in 0..MAX_ATTEMPTS {
+                        match self.registry.lock().await.select(expert_id).await {
+                            Ok(c) => {
+                                if attempt > 0 {
+                                    log::info!(
+                                        "controller executor: worker found for {expert_id} on attempt {}",
+                                        attempt + 1
+                                    );
+                                }
+                                found = Some(c);
+                                break;
                             }
-                            found = Some(c);
-                            break;
-                        }
-                        Err(e) => {
-                            let backoff = std::time::Duration::from_secs(1u64 << attempt.min(4));
-                            log::info!(
-                                "controller executor: no worker for {expert_id} \
-                                 (attempt {}/{MAX_ATTEMPTS}), retrying in {:?}: {e}",
-                                attempt + 1,
-                                backoff
-                            );
-                            last_err = Some(e);
-                            tokio::time::sleep(backoff).await;
+                            Err(e) => {
+                                let backoff =
+                                    std::time::Duration::from_secs(1u64 << attempt.min(4));
+                                log::info!(
+                                    "controller executor: no worker for {expert_id} \
+                                     (attempt {}/{MAX_ATTEMPTS}), retrying in {:?}: {e}",
+                                    attempt + 1,
+                                    backoff
+                                );
+                                last_err = Some(e);
+                                tokio::time::sleep(backoff).await;
+                            }
                         }
                     }
-                }
-                match found {
-                    Some(c) => c,
-                    None => {
-                        let err = ExpertError::NoWorker {
-                            expert_id: expert_id.to_owned(),
-                            message: format!(
-                                "no worker after {MAX_ATTEMPTS} attempts: {last_err:?}"
-                            ),
-                        };
-                        log::error!("controller executor: {err}");
-                        self.mark_egress_failed(&egress_meta, err.clone())?;
-                        for handle in handles {
-                            handle.abort();
+                    match found {
+                        Some(c) => Ok(c),
+                        None => {
+                            let err = ExpertError::NoWorker {
+                                expert_id: expert_id.to_owned(),
+                                message: format!(
+                                    "no worker after {MAX_ATTEMPTS} attempts: {last_err:?}"
+                                ),
+                            };
+                            log::error!("controller executor: {err}");
+                            self.mark_egress_failed(&egress_meta, err.clone())?;
+                            for handle in handles.iter() {
+                                handle.abort();
+                            }
+                            self.cleanup_egress_requests(&egress_meta);
+                            Err(EKError::NotFound(err.to_string()))
                         }
-                        self.cleanup_egress_requests(&egress_meta);
-                        return Err(EKError::NotFound(err.to_string()));
                     }
-                }
+                };
+                let selected = selected.instrument(schedule_span).await;
+                drop(schedule_timer);
+                selected?
             };
             self.mark_egress_running(&egress_meta)?;
-            chips.push((expert_id.to_owned(), egress_meta.to_owned()));
+            chips.push((
+                expert_id.to_owned(),
+                egress_meta.to_owned(),
+                expert_timer,
+                expert_span.clone(),
+            ));
 
             let seq_gids = egress_meta
                 .iter()
                 .map(|e| e.seq_gid)
                 .collect::<Vec<GlobalSeqId>>();
 
-            let egress_tensor = self.assemble_seq_tensors(seq_gids)?;
+            let egress_tensor = {
+                let timer = {
+                    let _entered = expert_span.enter();
+                    StageTimer::start(
+                        TraceLabels::new("controller", "controller.assemble")
+                            .path("fallback_controller")
+                            .expert_call_id(expert_call_id)
+                            .expert_id(expert_id)
+                            .num_tokens(num_tokens),
+                    )
+                };
+                let span = timer.span();
+                let _entered = span.enter();
+                let tensor = self.assemble_seq_tensors(seq_gids)?;
+                drop(timer);
+                tensor
+            };
             log::debug!("egress tensor shape={:?}", egress_tensor.size());
-            let serialized_tensor = TchTensor::from(egress_tensor).serialize();
+            let serialized_tensor = {
+                let timer = {
+                    let _entered = expert_span.enter();
+                    StageTimer::start(
+                        TraceLabels::new("controller", "controller.serialize")
+                            .path("fallback_controller")
+                            .expert_call_id(expert_call_id)
+                            .expert_id(expert_id)
+                            .num_tokens(num_tokens),
+                    )
+                };
+                let span = timer.span();
+                let _entered = span.enter();
+                let tensor = TchTensor::from(egress_tensor).serialize();
+                drop(timer);
+                tensor
+            };
             let seqs = egress_meta
                 .iter()
                 .map(|_e| v1::forward_req::SequenceInfo {
@@ -372,6 +436,14 @@ impl NaiveExecutor {
                                 tensor: serialized_tensor,
                                 sequences: seqs,
                             };
+                            let send_timer = StageTimer::start(
+                                TraceLabels::new("controller", "controller.send_worker")
+                                    .path("fallback_controller")
+                                    .expert_call_id(expert_call_id)
+                                    .expert_id(expert_id.as_str())
+                                    .num_tokens(num_tokens),
+                            );
+                            let send_span = send_timer.span();
 
                             let start = time::Instant::now();
                             let _d = Defers::defer(Box::new(move || {
@@ -381,19 +453,26 @@ impl NaiveExecutor {
                                     .with_label_values(&[settings.inference.model_name.as_str()])
                                     .observe(elapsed.as_micros() as f64);
                             }));
-                            cli.forward(req)
-                                .await
-                                .map(|resp| ForwardResponse::Grpc(resp.into_inner()))
-                                .map_err(|e| {
-                                    let message = format!("gRPC forward error: {e}");
-                                    if e.code() == tonic::Code::Internal {
-                                        ExpertError::Compute { expert_id, message }
-                                    } else {
-                                        ExpertError::Transport { expert_id, message }
-                                    }
-                                })
+                            let result = async {
+                                let mut req = tonic::Request::new(req);
+                                inject_current_trace_context(req.metadata_mut());
+                                cli.forward(req).await
+                            }
+                            .instrument(send_span)
+                            .await
+                            .map(|resp| ForwardResponse::Grpc(resp.into_inner()))
+                            .map_err(|e| {
+                                let message = format!("gRPC forward error: {e}");
+                                if e.code() == tonic::Code::Internal {
+                                    ExpertError::Compute { expert_id, message }
+                                } else {
+                                    ExpertError::Transport { expert_id, message }
+                                }
+                            });
+                            drop(send_timer);
+                            result
                         }
-                        .in_current_span(),
+                        .instrument(expert_span.clone()),
                     );
                     handles.push(f);
                 }
@@ -514,7 +593,9 @@ impl NaiveExecutor {
         tit.stop("egress_req_sent");
 
         for (egress_idx, handle) in handles.into_iter().enumerate() {
-            let egress = chips[egress_idx].clone();
+            let (expert_id_for_chip, egress_meta_for_chip, _expert_timer, expert_span) =
+                &chips[egress_idx];
+            let egress = (expert_id_for_chip.clone(), egress_meta_for_chip.clone());
             let res = match handle.await {
                 Ok(Ok(res)) => res,
                 Ok(Err(err)) => {
@@ -532,16 +613,31 @@ impl NaiveExecutor {
                     return Err(EKError::RuntimeError(err.to_string()));
                 }
             };
-            let res_safetensor = match SafeTensors::deserialize(res.output_tensor()) {
-                Ok(res) => res,
-                Err(e) => {
-                    let err = ExpertError::Compute {
-                        expert_id: egress.0.clone(),
-                        message: format!("invalid output tensor: {e}"),
-                    };
-                    self.mark_egress_failed(&egress.1, err.clone())?;
-                    self.cleanup_egress_requests(&egress.1);
-                    return Err(EKError::RuntimeError(err.to_string()));
+            let res_safetensor = {
+                let timer = {
+                    let _entered = expert_span.enter();
+                    StageTimer::start(
+                        TraceLabels::new("controller", "controller.deserialize")
+                            .path("fallback_controller")
+                            .expert_id(egress.0.as_str())
+                            .num_tokens(egress.1.len()),
+                    )
+                };
+                let span = timer.span();
+                let _entered = span.enter();
+                let parsed = SafeTensors::deserialize(res.output_tensor());
+                drop(timer);
+                match parsed {
+                    Ok(res) => res,
+                    Err(e) => {
+                        let err = ExpertError::Compute {
+                            expert_id: egress.0.clone(),
+                            message: format!("invalid output tensor: {e}"),
+                        };
+                        self.mark_egress_failed(&egress.1, err.clone())?;
+                        self.cleanup_egress_requests(&egress.1);
+                        return Err(EKError::RuntimeError(err.to_string()));
+                    }
                 }
             };
             // TODO: hardcode safe tensor name
@@ -557,7 +653,22 @@ impl NaiveExecutor {
                     return Err(EKError::RuntimeError(err.to_string()));
                 }
             };
-            let res_tensor = TchTensor::from(&view).inner();
+            let res_tensor = {
+                let timer = {
+                    let _entered = expert_span.enter();
+                    StageTimer::start(
+                        TraceLabels::new("controller", "controller.merge")
+                            .path("fallback_controller")
+                            .expert_id(egress.0.as_str())
+                            .num_tokens(egress.1.len()),
+                    )
+                };
+                let span = timer.span();
+                let _entered = span.enter();
+                let tensor = TchTensor::from(&view).inner();
+                drop(timer);
+                tensor
+            };
 
             log::debug!("received tensor shape={:?}", res_tensor.size());
             for (seq_idx, egress_meta) in egress.1.iter().enumerate() {
@@ -656,7 +767,6 @@ impl NaiveExecutor {
         Ok(())
     }
 
-    #[instrument(skip(self, req))]
     fn break_down_to_egress(&mut self, req: &v1::ForwardReq, req_id: ReqId) {
         for (idx, seq) in req.sequences.iter().enumerate() {
             // update pending_seq

--- a/ek-computation/src/controller/mod.rs
+++ b/ek-computation/src/controller/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     state::io::StateReaderImpl,
 };
 use ek_base::error::EKResult;
+use ek_base::tracing::grpc::OTelGrpcServerMiddleware;
 use metrics::spawn_metrics_server;
 use service::control::PlanServiceImpl;
 use std::sync::Arc;
@@ -48,8 +49,7 @@ pub async fn controller_main() -> EKResult<()> {
 
     let state_srv = tokio::task::spawn(async move {
         let srv = controller::service::state::StateServerImpl::new();
-        let routing_srv =
-            controller::service::routing::RoutingServiceImpl::new(broadcaster_intra);
+        let routing_srv = controller::service::routing::RoutingServiceImpl::new(broadcaster_intra);
         let intra_addr = format!(
             "{}:{}",
             settings.controller.listen, settings.controller.ports.intra
@@ -76,16 +76,15 @@ pub async fn controller_main() -> EKResult<()> {
         .parse()
         .unwrap();
 
-        // let layer = tower::ServiceBuilder::new()
-        //     .layer_fn(OTelGrpcServerMiddleware::new)
-        //     .into_inner();
+        let layer = tower::ServiceBuilder::new()
+            .layer_fn(OTelGrpcServerMiddleware::new)
+            .into_inner();
 
         log::info!("computation server listening on {inter_addr}");
         let plan_srv = PlanServiceImpl::new();
-        let routing_srv =
-            controller::service::routing::RoutingServiceImpl::new(broadcaster_clone);
+        let routing_srv = controller::service::routing::RoutingServiceImpl::new(broadcaster_clone);
         let err = tonic::transport::Server::builder()
-            // .layer(layer)
+            .layer(layer)
             .add_service(
                 ComputationServiceServer::new(srv)
                     .max_decoding_message_size(1024 * 1024 * 1024)

--- a/ek-computation/src/controller/registry.rs
+++ b/ek-computation/src/controller/registry.rs
@@ -1,14 +1,14 @@
 use std::{
     collections::HashMap,
     sync::{
-        atomic::{AtomicUsize, Ordering},
         Arc, OnceLock,
+        atomic::{AtomicUsize, Ordering},
     },
     time::Duration,
 };
 
 use crate::{
-    shmq::{rdma_impl::RdmaQueue, GeneralShmQueueBytes, RdmaEndpointClient, ShmQueue},
+    shmq::{GeneralShmQueueBytes, RdmaEndpointClient, ShmQueue, rdma_impl::RdmaQueue},
     state::io::StateReaderImpl,
 };
 use ek_base::{

--- a/ek-computation/src/controller/service/compute.rs
+++ b/ek-computation/src/controller/service/compute.rs
@@ -9,6 +9,7 @@ use crate::{
         executor::{Executor, get_executor},
         metrics::METRIC_CONTROLLER_LAYER,
     },
+    observability::{StageTimer, TraceLabels, child_span_from_traceparent, extract_traceparent},
     proto::ek::worker::v1::{self, computation_service_server::ComputationService},
 };
 
@@ -32,11 +33,6 @@ impl ComputationService for ComputationProxyServiceImpl {
 }
 
 impl ComputationProxyServiceImpl {
-    #[tracing::instrument(
-        skip(self, request),
-        level = "info",
-        fields(method = "ComputationProxyServiceImpl::forward",)
-    )]
     async fn inner_controller_forward(
         &self,
         request: tonic::Request<v1::ForwardReq>,
@@ -45,6 +41,12 @@ impl ComputationProxyServiceImpl {
         log::info!(seq_len; "forward request in controller start");
         let start = std::time::Instant::now();
         let settings = get_ek_settings();
+        let traceparent = extract_traceparent(request.metadata());
+        let forward_labels = TraceLabels::new("controller", "controller.forward")
+            .path("fallback_controller")
+            .num_tokens(seq_len);
+        let forward_span = child_span_from_traceparent(&forward_labels, traceparent.as_str());
+        let _forward_timer = StageTimer::start_with_span(forward_labels, forward_span.clone());
 
         let cloned_start = start;
         let _d = Defers::defer(Box::new(move || {
@@ -55,10 +57,22 @@ impl ComputationProxyServiceImpl {
                 .observe(elapsed.as_micros() as f64);
         }));
 
-        let mut rx = {
-            let mut lg = self.executor.lock().await;
-            lg.submit(request.get_ref()).await?
+        let submit_timer = {
+            let _entered = forward_span.enter();
+            StageTimer::start(
+                TraceLabels::new("controller", "controller.submit")
+                    .path("fallback_controller")
+                    .num_tokens(seq_len),
+            )
         };
+        let submit_span = submit_timer.span();
+        let mut rx = async {
+            let mut lg = self.executor.lock().await;
+            lg.submit(request.get_ref()).await
+        }
+        .instrument(submit_span)
+        .await?;
+        drop(submit_timer);
 
         let exec_bg = self.executor.clone();
         let (err_tx, mut err_rx) = mpsc::channel(1);
@@ -72,18 +86,28 @@ impl ComputationProxyServiceImpl {
                     err_tx.send(err).await.unwrap();
                 }
             }
-            .in_current_span(),
+            .instrument(forward_span.clone()),
         );
 
+        let wait_timer = {
+            let _entered = forward_span.enter();
+            StageTimer::start(
+                TraceLabels::new("controller", "controller.wait_result")
+                    .path("fallback_controller")
+                    .num_tokens(seq_len),
+            )
+        };
+        let wait_span = wait_timer.span();
         tokio::select! {
-            err = err_rx.recv() => {
+            err = err_rx.recv().instrument(wait_span.clone()) => {
                 if let Some(err) = err {
                     log::error!("executor error: {err:?}");
                     return Err(tonic::Status::internal(format!("executor error: {err:?}")));
                 }
                 // err_tx dropped: exec task completed without error, wait for result
             }
-            res = rx.recv() => {
+            res = rx.recv().instrument(wait_span) => {
+                drop(wait_timer);
                 let elapsed_ms = start.elapsed().as_millis();
                 log::info!(elapsed_ms; "forward request in controller done");
                 if let Some(resp) = res {
@@ -93,6 +117,7 @@ impl ComputationProxyServiceImpl {
                 }
             }
         }
+        drop(wait_timer);
         let elapsed_ms = start.elapsed().as_millis();
         log::info!(elapsed_ms; "forward request in controller done");
         match rx.recv().await {

--- a/ek-computation/src/lib.rs
+++ b/ek-computation/src/lib.rs
@@ -2,6 +2,7 @@ pub mod backend;
 pub mod controller;
 pub mod ffn;
 pub mod metrics;
+pub mod observability;
 pub mod onnx;
 pub mod proto;
 mod schema;

--- a/ek-computation/src/observability.rs
+++ b/ek-computation/src/observability.rs
@@ -1,0 +1,203 @@
+use std::{
+    collections::HashMap,
+    sync::atomic::{AtomicU64, Ordering},
+    time::Instant,
+};
+
+use opentelemetry::propagation::{Extractor, Injector};
+use tonic::metadata::MetadataMap;
+use tracing::{Level, Span};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+static REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+static EXPERT_CALL_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Clone)]
+pub struct TraceLabels {
+    pub component: &'static str,
+    pub stage: &'static str,
+    pub path: &'static str,
+    pub request_id: u64,
+    pub layer_id: u64,
+    pub expert_call_id: u64,
+    pub expert_id: String,
+    pub worker: String,
+    pub num_tokens: usize,
+}
+
+impl TraceLabels {
+    pub fn new(component: &'static str, stage: &'static str) -> Self {
+        Self {
+            component,
+            stage,
+            path: "unknown",
+            request_id: 0,
+            layer_id: 0,
+            expert_call_id: 0,
+            expert_id: String::new(),
+            worker: String::new(),
+            num_tokens: 0,
+        }
+    }
+
+    pub fn path(mut self, path: &'static str) -> Self {
+        self.path = path;
+        self
+    }
+
+    pub fn request_id(mut self, request_id: u64) -> Self {
+        self.request_id = request_id;
+        self
+    }
+
+    pub fn layer_id(mut self, layer_id: u64) -> Self {
+        self.layer_id = layer_id;
+        self
+    }
+
+    pub fn expert_call_id(mut self, expert_call_id: u64) -> Self {
+        self.expert_call_id = expert_call_id;
+        self
+    }
+
+    pub fn expert_id(mut self, expert_id: impl Into<String>) -> Self {
+        self.expert_id = expert_id.into();
+        self
+    }
+
+    pub fn worker(mut self, worker: impl Into<String>) -> Self {
+        self.worker = worker.into();
+        self
+    }
+
+    pub fn num_tokens(mut self, num_tokens: usize) -> Self {
+        self.num_tokens = num_tokens;
+        self
+    }
+}
+
+pub struct StageTimer {
+    labels: TraceLabels,
+    start: Instant,
+    span: Span,
+}
+
+impl StageTimer {
+    pub fn start(labels: TraceLabels) -> Self {
+        let span = trace_span(&labels);
+        Self::start_with_span(labels, span)
+    }
+
+    pub fn start_with_span(labels: TraceLabels, span: Span) -> Self {
+        Self {
+            labels,
+            start: Instant::now(),
+            span,
+        }
+    }
+
+    pub fn span(&self) -> Span {
+        self.span.clone()
+    }
+}
+
+impl Drop for StageTimer {
+    fn drop(&mut self) {
+        let elapsed_us = self.start.elapsed().as_micros() as u64;
+        let labels = &self.labels;
+        self.span.in_scope(|| {
+            tracing::info!(
+                elapsed_us,
+                component = labels.component,
+                stage = labels.stage,
+                path = labels.path,
+                request_id = labels.request_id,
+                layer_id = labels.layer_id,
+                expert_call_id = labels.expert_call_id,
+                expert_id = labels.expert_id.as_str(),
+                worker = labels.worker.as_str(),
+                num_tokens = labels.num_tokens,
+                "expert-kit trace stage done",
+            );
+        });
+    }
+}
+
+pub fn next_request_id() -> u64 {
+    REQUEST_ID.fetch_add(1, Ordering::SeqCst)
+}
+
+pub fn next_expert_call_id() -> u64 {
+    EXPERT_CALL_ID.fetch_add(1, Ordering::SeqCst)
+}
+
+pub fn trace_span(labels: &TraceLabels) -> Span {
+    tracing::span!(
+        Level::INFO,
+        "ek.trace",
+        otel.name = labels.stage,
+        component = labels.component,
+        stage = labels.stage,
+        path = labels.path,
+        request_id = labels.request_id,
+        layer_id = labels.layer_id,
+        expert_call_id = labels.expert_call_id,
+        expert_id = labels.expert_id.as_str(),
+        worker = labels.worker.as_str(),
+        num_tokens = labels.num_tokens,
+    )
+}
+
+pub fn child_span_from_traceparent(labels: &TraceLabels, traceparent: &str) -> Span {
+    let span = trace_span(labels);
+    if !traceparent.is_empty() {
+        let mut headers = HashMap::new();
+        headers.insert("traceparent".to_string(), traceparent.to_string());
+        let extractor = StringMapExtractor(headers);
+        let ctx = opentelemetry::global::get_text_map_propagator(|propagator| {
+            propagator.extract(&extractor)
+        });
+        span.set_parent(ctx);
+    }
+    span
+}
+
+pub fn extract_traceparent(metadata: &MetadataMap) -> String {
+    metadata
+        .get("traceparent")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_string()
+}
+
+pub fn inject_current_trace_context(metadata: &mut MetadataMap) {
+    let ctx = Span::current().context();
+    let mut injector = MetadataInjector(metadata);
+    opentelemetry::global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(&ctx, &mut injector);
+    });
+}
+
+struct MetadataInjector<'a>(&'a mut MetadataMap);
+
+impl Injector for MetadataInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        if let Ok(key) = tonic::metadata::MetadataKey::from_bytes(key.as_bytes())
+            && let Ok(value) = value.parse()
+        {
+            self.0.insert(key, value);
+        }
+    }
+}
+
+struct StringMapExtractor(HashMap<String, String>);
+
+impl Extractor for StringMapExtractor {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).map(String::as_str)
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(String::as_str).collect()
+    }
+}

--- a/ek-computation/src/worker/core.rs
+++ b/ek-computation/src/worker/core.rs
@@ -1,10 +1,13 @@
 use super::manager::{ExpertDB, ExpertDBSync, get_expert_db, get_expert_db_sync};
-use crate::{controller::registry::ExpertIdRef, proto::ek};
+use crate::{
+    controller::registry::ExpertIdRef,
+    observability::{StageTimer, TraceLabels},
+    proto::ek,
+};
 use core::fmt;
 use ek_base::error::EKResult;
 use std::sync::{Arc, OnceLock};
 use tokio;
-use tracing::instrument;
 
 /// Async version of EKInstanceGate for non-compute operations
 pub struct EKInstanceGateAsync {
@@ -73,7 +76,6 @@ impl EKInstanceGateSync {
     }
 
     /// Synchronous forward computation - optimized for compute-intensive tasks
-    #[instrument(skip(self, req))]
     pub fn forward_sync(
         &self,
         req: ek::worker::v1::ForwardReq,
@@ -91,17 +93,52 @@ impl EKInstanceGateSync {
         assert!(!req.sequences.is_empty());
         assert!(req.sequences[0].experts.len() == 1);
         let exp_id = &req.sequences[0].experts[0];
+        let settings = ek_base::config::get_ek_settings();
+        let num_tokens = req.sequences.len();
 
         // Load expert synchronously from shared database
-        let exp = self.experts.load(exp_id)?;
+        let exp = {
+            let timer = StageTimer::start(
+                TraceLabels::new("worker", "worker.load_expert")
+                    .path("worker")
+                    .worker(settings.worker.id.as_str())
+                    .expert_id(exp_id)
+                    .num_tokens(num_tokens),
+            );
+            let span = timer.span();
+            let _entered = span.enter();
+            self.experts.load(exp_id)?
+        };
 
         let now = std::time::Instant::now();
         tracing::debug!("[L3 {:?}] exp_backend.forward_sync() started", exp_id,);
 
         // Perform synchronous computation
-        let st = safetensors::SafeTensors::deserialize(&input_tensor).unwrap();
+        let st = {
+            let timer = StageTimer::start(
+                TraceLabels::new("worker", "worker.deserialize")
+                    .path("worker")
+                    .worker(settings.worker.id.as_str())
+                    .expert_id(exp_id)
+                    .num_tokens(num_tokens),
+            );
+            let span = timer.span();
+            let _entered = span.enter();
+            safetensors::SafeTensors::deserialize(&input_tensor)?
+        };
         let tv = st.tensor("data")?;
-        let res = exp.forward(&tv)?;
+        let res = {
+            let timer = StageTimer::start(
+                TraceLabels::new("worker", "worker.compute")
+                    .path("worker")
+                    .worker(settings.worker.id.as_str())
+                    .expert_id(exp_id)
+                    .num_tokens(num_tokens),
+            );
+            let span = timer.span();
+            let _entered = span.enter();
+            exp.forward(&tv)?
+        };
 
         tracing::debug!(
             "[L3 {:?}] exp_backend.forward_sync() completed in {:?}",
@@ -113,8 +150,19 @@ impl EKInstanceGateSync {
 
         tracing::debug!("output bytes_len={}", output_bytes.len());
 
-        let resp = ek::worker::v1::ForwardResp {
-            output_tensor: output_bytes,
+        let resp = {
+            let timer = StageTimer::start(
+                TraceLabels::new("worker", "worker.serialize")
+                    .path("worker")
+                    .worker(settings.worker.id.as_str())
+                    .expert_id(exp_id)
+                    .num_tokens(num_tokens),
+            );
+            let span = timer.span();
+            let _entered = span.enter();
+            ek::worker::v1::ForwardResp {
+                output_tensor: output_bytes,
+            }
         };
 
         tracing::debug!(
@@ -131,10 +179,49 @@ impl EKInstanceGateSync {
         expert_id: ExpertIdRef<'_>,
         input_tensor: &[u8],
     ) -> EKResult<Vec<u8>> {
-        let exp = self.experts.load(expert_id)?;
-        let st = safetensors::SafeTensors::deserialize(input_tensor)?;
+        let settings = ek_base::config::get_ek_settings();
+        let exp = {
+            let timer = StageTimer::start(
+                TraceLabels::new("worker", "worker.load_expert")
+                    .path("worker")
+                    .worker(settings.worker.id.as_str())
+                    .expert_id(expert_id),
+            );
+            let span = timer.span();
+            let _entered = span.enter();
+            self.experts.load(expert_id)?
+        };
+        let st = {
+            let timer = StageTimer::start(
+                TraceLabels::new("worker", "worker.deserialize")
+                    .path("worker")
+                    .worker(settings.worker.id.as_str())
+                    .expert_id(expert_id),
+            );
+            let span = timer.span();
+            let _entered = span.enter();
+            safetensors::SafeTensors::deserialize(input_tensor)?
+        };
         let tv = st.tensor("data")?;
-        let res = exp.forward(&tv)?;
+        let res = {
+            let timer = StageTimer::start(
+                TraceLabels::new("worker", "worker.compute")
+                    .path("worker")
+                    .worker(settings.worker.id.as_str())
+                    .expert_id(expert_id),
+            );
+            let span = timer.span();
+            let _entered = span.enter();
+            exp.forward(&tv)?
+        };
+        let timer = StageTimer::start(
+            TraceLabels::new("worker", "worker.serialize")
+                .path("worker")
+                .worker(settings.worker.id.as_str())
+                .expert_id(expert_id),
+        );
+        let span = timer.span();
+        let _entered = span.enter();
         Ok(res)
     }
 

--- a/ek-computation/src/worker/mod.rs
+++ b/ek-computation/src/worker/mod.rs
@@ -32,8 +32,7 @@ use ek_base::{config::get_ek_settings, error::EKResult};
 
 /// Set to true on SIGTERM; the heartbeat stream reads this and sets last_will=true
 /// in all subsequent heartbeats so the controller can start proactive migration.
-static LAST_WILL: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
+static LAST_WILL: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
 pub fn get_last_will() -> bool {
     LAST_WILL.load(Ordering::Relaxed)
@@ -158,9 +157,8 @@ pub async fn worker_main() -> EKResult<()> {
     {
         let wm_listen = settings.weight.wm_listen.clone();
         let wm_clone = wm.clone();
-        let wm_addr: std::net::SocketAddr = wm_listen
-            .parse()
-            .expect("invalid weight.wm_listen address");
+        let wm_addr: std::net::SocketAddr =
+            wm_listen.parse().expect("invalid weight.wm_listen address");
         tokio::spawn(async move {
             log::info!("Peer weight HTTP server listening on {wm_addr}");
             match peer_server::start_peer_server(wm_clone, &wm_addr).await {
@@ -201,12 +199,8 @@ pub async fn worker_main() -> EKResult<()> {
         log::info!("ek hostname: {worker_id:}");
         let control_endpoint = x::get_controller_addr();
         log::info!("control endpoint {:}", control_endpoint.uri());
-        let mut state_client = StateClient::new_with_rdma_tcp_port(
-            control_endpoint,
-            &worker_id,
-            rdma_tcp_port,
-            wm,
-        );
+        let mut state_client =
+            StateClient::new_with_rdma_tcp_port(control_endpoint, &worker_id, rdma_tcp_port, wm);
         state_client.set_preemption_notifier(preemption_tx);
         if let Err(e) = state_client.run(cli_cancel).await {
             log::error!("state client error {e:}");
@@ -433,9 +427,9 @@ pub async fn worker_main() -> EKResult<()> {
     tokio::spawn(async move {
         #[cfg(unix)]
         {
-            if let Ok(mut sig) = tokio::signal::unix::signal(
-                tokio::signal::unix::SignalKind::terminate(),
-            ) {
+            if let Ok(mut sig) =
+                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            {
                 sig.recv().await;
                 let _ = sigterm_tx.send(());
                 return;
@@ -471,7 +465,9 @@ pub async fn worker_main() -> EKResult<()> {
         match tokio::time::timeout(
             Duration::from_secs(settings.worker.shutdown_grace_secs),
             preemption_rx,
-        ).await {
+        )
+        .await
+        {
             Ok(Ok(())) => {
                 log::info!("Controller confirmed preemption complete");
             }

--- a/ek-computation/src/worker/server.rs
+++ b/ek-computation/src/worker/server.rs
@@ -11,13 +11,13 @@ use dashmap::DashMap;
 
 use crate::{
     metrics::{METRIC_WORKER_EXPERT_ACTIVATION, METRIC_WORKER_FORWARD},
+    observability::{StageTimer, TraceLabels, child_span_from_traceparent, extract_traceparent},
     proto::ek::worker::v1::{
         ForwardReq, ForwardResp, computation_service_server::ComputationService,
     },
 };
 use ek_base::utils::Defers;
 use tonic::{Request, Response, Status};
-use tracing::instrument;
 
 /// Per-expert request counters, reset after each heartbeat snapshot.
 static REQUEST_COUNTS: LazyLock<DashMap<String, AtomicU64>> = LazyLock::new(DashMap::new);
@@ -36,7 +36,6 @@ pub fn snapshot_and_reset() -> HashMap<String, u64> {
 }
 
 use super::core::{EKInstanceGateSync, get_instance_gate_sync};
-use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 #[derive(Debug)]
 pub struct BasicExpertImpl {
@@ -59,7 +58,6 @@ impl BasicExpertImpl {
 
 #[tonic::async_trait]
 impl ComputationService for BasicExpertImpl {
-    #[instrument(skip(self, request))]
     async fn forward(&self, request: Request<ForwardReq>) -> Result<Response<ForwardResp>, Status> {
         let now = Instant::now();
         let exp_id = request.get_ref().sequences[0].experts[0].clone();
@@ -83,6 +81,16 @@ impl BasicExpertImpl {
         );
         let exp_id = request.get_ref().sequences[0].experts[0].clone();
         let start = Instant::now();
+        let settings = ek_base::config::get_ek_settings();
+        let num_tokens = request.get_ref().sequences.len();
+        let traceparent = extract_traceparent(request.metadata());
+        let forward_labels = TraceLabels::new("worker", "worker.forward")
+            .path("worker")
+            .worker(settings.worker.id.as_str())
+            .expert_id(exp_id.as_str())
+            .num_tokens(num_tokens);
+        let forward_span = child_span_from_traceparent(&forward_labels, traceparent.as_str());
+        let _forward_timer = StageTimer::start_with_span(forward_labels, forward_span.clone());
 
         // Increment per-expert counter (reset each heartbeat)
         REQUEST_COUNTS
@@ -91,7 +99,6 @@ impl BasicExpertImpl {
             .fetch_add(1, Ordering::Relaxed);
 
         let start_cloned = start;
-        let settings = ek_base::config::get_ek_settings();
 
         // Record metrics
         METRIC_WORKER_EXPERT_ACTIVATION
@@ -135,15 +142,22 @@ impl BasicExpertImpl {
         // Use sync gate for compute-intensive operations
         let gate_sync = self.gate_sync;
 
-        // Capture current tracing context for the blocking task
-        let cx = tracing::Span::current().context();
-
-        let cx_clone = cx.clone();
+        let forward_span_for_task = forward_span.clone();
+        let queue_wait_timer = {
+            let _entered = forward_span.enter();
+            StageTimer::start(
+                TraceLabels::new("worker", "worker.queue_wait")
+                    .path("worker")
+                    .worker(settings.worker.id.as_str())
+                    .expert_id(exp_id.as_str())
+                    .num_tokens(num_tokens),
+            )
+        };
 
         // Run synchronous computation in blocking task
         let res = tokio::task::spawn_blocking(move || {
-            let _guard = cx_clone.attach();
-
+            drop(queue_wait_timer);
+            let _entered = forward_span_for_task.enter();
             // Perform synchronous forward computation
             gate_sync.forward_sync(req_inner)
         })

--- a/ek-integration/expertkit-transport-rs/Cargo.toml
+++ b/ek-integration/expertkit-transport-rs/Cargo.toml
@@ -22,6 +22,13 @@ serde_json = "1.0"
 anyhow = "1.0"
 log = { workspace = true }
 env_logger = { workspace = true }
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true }
+opentelemetry-otlp = { workspace = true }
+opentelemetry-semantic-conventions = { workspace = true }
+tracing = { workspace = true }
+tracing-opentelemetry = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 # gRPC dependencies (Phase 2)
 tonic = "0.11"

--- a/ek-integration/expertkit-transport-rs/python/expertkit_transport/__init__.py
+++ b/ek-integration/expertkit-transport-rs/python/expertkit_transport/__init__.py
@@ -2,7 +2,26 @@
 ExpertKit Transport Library
 """
 
-from ._lib import PyExpertKitClient as ExpertKitClient
+import atexit
+import logging
+
+from ._lib import (
+    PyExpertKitClient as ExpertKitClient,
+    flush_tracing,
+    shutdown_tracing,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _shutdown_tracing_at_exit():
+    try:
+        shutdown_tracing()
+    except Exception as exc:
+        logger.debug("Failed to shutdown ExpertKit tracing at exit: %s", exc)
+
+
+atexit.register(_shutdown_tracing_at_exit)
 
 __version__ = "0.1.0"
-__all__ = ["ExpertKitClient"]
+__all__ = ["ExpertKitClient", "flush_tracing", "shutdown_tracing"]

--- a/ek-integration/expertkit-transport-rs/src/client.rs
+++ b/ek-integration/expertkit-transport-rs/src/client.rs
@@ -4,15 +4,71 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tonic::transport::Channel;
+use tracing::{Instrument, Span};
 
-use crate::routing::RoutingClient;
-use crate::transport::{ExpertRequest, Transport, auto::AutoTransport};
-use crate::transport::grpc::proto::ek::worker::v1::{
-    ForwardReq, forward_req::SequenceInfo, computation_service_client::ComputationServiceClient,
+use crate::observability::{
+    StageTimer, TraceLabels, infer_layer_id, inject_current_trace_context, next_expert_call_id,
+    next_layer_id, next_request_id,
 };
+use crate::routing::RoutingClient;
+use crate::transport::grpc::proto::ek::worker::v1::{
+    ForwardReq, computation_service_client::ComputationServiceClient, forward_req::SequenceInfo,
+};
+use crate::transport::{ExpertRequest, Transport, auto::AutoTransport};
 use crate::utils::{deserialize_safetensor_2_tch_tensor, serialize_tch_tensor_2_safetensor};
 
 use tch::Tensor;
+
+struct ForwardTrace {
+    request_id: u64,
+    layer_id: u64,
+    layer_span: Span,
+    _request_timer: StageTimer,
+    _layer_timer: StageTimer,
+}
+
+impl ForwardTrace {
+    fn start(
+        expert_ids: &[Vec<String>],
+        batch_size: usize,
+        hidden_dim: usize,
+        path: &'static str,
+    ) -> Self {
+        let request_id = next_request_id();
+        let inferred_layer_id = infer_layer_id(expert_ids, next_layer_id());
+        let request_timer = StageTimer::start(
+            TraceLabels::new("frontend", "frontend.request")
+                .path(path)
+                .request_id(request_id)
+                .layer_id(inferred_layer_id)
+                .num_tokens(batch_size),
+        );
+        let request_span = request_timer.span();
+        let layer_timer = {
+            let _entered = request_span.enter();
+            StageTimer::start(
+                TraceLabels::new("frontend", "frontend.layer")
+                    .path(path)
+                    .request_id(request_id)
+                    .layer_id(inferred_layer_id)
+                    .num_tokens(batch_size),
+            )
+        };
+        let _ = hidden_dim;
+        Self {
+            request_id,
+            layer_id: inferred_layer_id,
+            layer_span: layer_timer.span(),
+            _request_timer: request_timer,
+            _layer_timer: layer_timer,
+        }
+    }
+
+    fn child_timer(&self, labels: TraceLabels) -> StageTimer {
+        let _entered = self.layer_span.enter();
+        StageTimer::start(labels.request_id(self.request_id).layer_id(self.layer_id))
+    }
+}
 
 /// Result of a single expert task execution
 enum ExpertTaskResult {
@@ -54,7 +110,9 @@ impl ExpertKitClient {
         routing.fetch_routing(None).await?;
 
         // Establish controller channel for fallback requests
-        let uri = if self.controller_addr.starts_with("http://") || self.controller_addr.starts_with("https://") {
+        let uri = if self.controller_addr.starts_with("http://")
+            || self.controller_addr.starts_with("https://")
+        {
             self.controller_addr.clone()
         } else {
             format!("http://{}", self.controller_addr)
@@ -86,6 +144,9 @@ impl ExpertKitClient {
         routing: Arc<RoutingClient>,
         pre_assigned_worker: crate::transport::grpc::proto::ek::control::v1::WorkerEndpoint,
         task_create_t: std::time::Instant,
+        request_id: u64,
+        layer_id: u64,
+        expert_call_id: u64,
     ) -> ExpertTaskResult {
         let sub_task_t = std::time::Instant::now();
 
@@ -107,19 +168,51 @@ impl ExpertKitClient {
             .collect();
 
         // Create index tensor and slice
-        let index_tensor = Tensor::from_slice(&seq_indices);
-        let expert_input = hidden_state.index_select(0, &index_tensor);
+        let expert_input = {
+            let timer = StageTimer::start(
+                TraceLabels::new("frontend", "frontend.tensor_slice")
+                    .path("direct_worker")
+                    .request_id(request_id)
+                    .layer_id(layer_id)
+                    .expert_call_id(expert_call_id)
+                    .expert_id(expert_id.as_str())
+                    .worker(worker_endpoint.grpc_addr.as_str())
+                    .num_tokens(seq_indices.len()),
+            );
+            let span = timer.span();
+            let _entered = span.enter();
+            let index_tensor = Tensor::from_slice(&seq_indices);
+            let tensor = hidden_state.index_select(0, &index_tensor);
+            drop(timer);
+            tensor
+        };
 
         // Serialize for network transfer
-        let tensor_bytes = match serialize_tch_tensor_2_safetensor(&expert_input) {
-            Ok(bytes) => bytes,
-            Err(e) => {
-                return ExpertTaskResult::Failed(
-                    expert_id,
-                    format!("Failed to serialize tensor: {}", e),
-                    Some(worker_endpoint.grpc_addr.clone()),
-                );
-            }
+        let tensor_bytes = {
+            let timer = StageTimer::start(
+                TraceLabels::new("frontend", "frontend.serialize")
+                    .path("direct_worker")
+                    .request_id(request_id)
+                    .layer_id(layer_id)
+                    .expert_call_id(expert_call_id)
+                    .expert_id(expert_id.as_str())
+                    .worker(worker_endpoint.grpc_addr.as_str())
+                    .num_tokens(seq_indices.len()),
+            );
+            let span = timer.span();
+            let _entered = span.enter();
+            let result = match serialize_tch_tensor_2_safetensor(&expert_input) {
+                Ok(bytes) => bytes,
+                Err(e) => {
+                    return ExpertTaskResult::Failed(
+                        expert_id,
+                        format!("Failed to serialize tensor: {}", e),
+                        Some(worker_endpoint.grpc_addr.clone()),
+                    );
+                }
+            };
+            drop(timer);
+            result
         };
         let num_sequences = seq_indices.len();
 
@@ -133,23 +226,52 @@ impl ExpertKitClient {
         );
 
         // Create request
-        let request = ExpertRequest::new(expert_id.clone(), tensor_bytes, num_sequences);
+        let request = ExpertRequest::new(expert_id.clone(), tensor_bytes, num_sequences)
+            .with_trace_context(request_id, layer_id, expert_call_id);
 
         let send_t = std::time::Instant::now();
+        let send_timer = StageTimer::start(
+            TraceLabels::new("frontend", "frontend.send_worker")
+                .path("direct_worker")
+                .request_id(request_id)
+                .layer_id(layer_id)
+                .expert_call_id(expert_call_id)
+                .expert_id(expert_id.as_str())
+                .worker(worker_endpoint.grpc_addr.as_str())
+                .num_tokens(num_sequences),
+        );
+        let send_span = send_timer.span();
         let result = transport
             .send_batch(&worker_endpoint, vec![request])
+            .instrument(send_span)
             .await;
+        drop(send_timer);
         let rtt_ms = send_t.elapsed().as_secs_f64() * 1000.0;
 
         // Track request completion (decrement inflight, update RTT and throughput)
-        routing.on_request_complete(&worker_endpoint, rtt_ms, num_sequences).await;
+        routing
+            .on_request_complete(&worker_endpoint, rtt_ms, num_sequences)
+            .await;
 
         let addr = worker_endpoint.grpc_addr.clone();
         match result {
             Ok(responses) => {
                 if let Some(response) = responses.into_iter().next() {
+                    let timer = StageTimer::start(
+                        TraceLabels::new("frontend", "frontend.deserialize")
+                            .path("direct_worker")
+                            .request_id(request_id)
+                            .layer_id(layer_id)
+                            .expert_call_id(expert_call_id)
+                            .expert_id(expert_id.as_str())
+                            .worker(addr.as_str())
+                            .num_tokens(num_sequences),
+                    );
+                    let span = timer.span();
+                    let _entered = span.enter();
                     match deserialize_safetensor_2_tch_tensor(&response.tensor_data) {
                         Ok(tensor) => {
+                            drop(timer);
                             debug!(
                                 "[Client-Time] 🔚 Sub-task for expert {} on worker {} completed in {:?} μs, send_batch took {:?} μs (RTT={:.2}ms), cost from task create time {:?} μs",
                                 expert_id,
@@ -161,14 +283,21 @@ impl ExpertKitClient {
                             );
                             ExpertTaskResult::Success(expert_id, tensor)
                         }
-                        Err(e) => ExpertTaskResult::Failed(
-                            expert_id,
-                            format!("Failed to deserialize response: {}", e),
-                            Some(addr),
-                        ),
+                        Err(e) => {
+                            drop(timer);
+                            ExpertTaskResult::Failed(
+                                expert_id,
+                                format!("Failed to deserialize response: {}", e),
+                                Some(addr),
+                            )
+                        }
                     }
                 } else {
-                    ExpertTaskResult::Failed(expert_id, "Empty response from worker".to_string(), Some(addr))
+                    ExpertTaskResult::Failed(
+                        expert_id,
+                        "Empty response from worker".to_string(),
+                        Some(addr),
+                    )
                 }
             }
             Err(e) => {
@@ -176,7 +305,11 @@ impl ExpertKitClient {
                     "[Client] Expert {} failed on worker {}: {}",
                     expert_id, addr, e
                 );
-                ExpertTaskResult::Failed(expert_id, format!("Worker request failed: {}", e), Some(addr))
+                ExpertTaskResult::Failed(
+                    expert_id,
+                    format!("Worker request failed: {}", e),
+                    Some(addr),
+                )
             }
         }
     }
@@ -190,6 +323,19 @@ impl ExpertKitClient {
     ) -> Result<Tensor> {
         let batch_size = hidden_state.size()[0] as usize;
         let hidden_dim = hidden_state.size()[1] as usize;
+        let trace = ForwardTrace::start(&expert_ids, batch_size, hidden_dim, "direct_worker");
+        self.forward_expert_tensor_direct(expert_ids, hidden_state, &trace)
+            .await
+    }
+
+    async fn forward_expert_tensor_direct(
+        &self,
+        expert_ids: Vec<Vec<String>>,
+        hidden_state: Tensor,
+        trace: &ForwardTrace,
+    ) -> Result<Tensor> {
+        let batch_size = hidden_state.size()[0] as usize;
+        let hidden_dim = hidden_state.size()[1] as usize;
 
         debug!(
             "[Client] forward_expert_tensor: batch_size={}, hidden_dim={}, device={:?}",
@@ -199,16 +345,26 @@ impl ExpertKitClient {
         );
 
         // Decompose by expert
-        let mut expert_to_sequences: HashMap<String, Vec<(usize, usize)>> = HashMap::new();
-
-        for (seq_idx, experts) in expert_ids.iter().enumerate() {
-            for (expert_idx, expert_id) in experts.iter().enumerate() {
-                expert_to_sequences
-                    .entry(expert_id.clone())
-                    .or_default()
-                    .push((seq_idx, expert_idx));
+        let expert_to_sequences: HashMap<String, Vec<(usize, usize)>> = {
+            let timer = trace.child_timer(
+                TraceLabels::new("frontend", "frontend.decompose")
+                    .path("direct_worker")
+                    .num_tokens(expert_ids.len()),
+            );
+            let span = timer.span();
+            let _entered = span.enter();
+            let mut expert_to_sequences: HashMap<String, Vec<(usize, usize)>> = HashMap::new();
+            for (seq_idx, experts) in expert_ids.iter().enumerate() {
+                for (expert_idx, expert_id) in experts.iter().enumerate() {
+                    expert_to_sequences
+                        .entry(expert_id.clone())
+                        .or_default()
+                        .push((seq_idx, expert_idx));
+                }
             }
-        }
+            drop(timer);
+            expert_to_sequences
+        };
 
         info!(
             "[Client] Decomposed {} sequences into {} unique experts",
@@ -250,7 +406,18 @@ impl ExpertKitClient {
             .iter()
             .map(|(eid, positions)| (eid.clone(), positions.len()))
             .collect();
-        let mut assignments = self.routing.assign_layer_batch(&expert_calls).await;
+        let routing_timer = trace.child_timer(
+            TraceLabels::new("frontend", "frontend.route")
+                .path("direct_worker")
+                .num_tokens(expert_calls.len()),
+        );
+        let routing_span = routing_timer.span();
+        let mut assignments = self
+            .routing
+            .assign_layer_batch(&expert_calls)
+            .instrument(routing_span)
+            .await;
+        drop(routing_timer);
 
         // Build requests: slice tensor directly and spawn tasks immediately
         let mut jobs: tokio::task::JoinSet<ExpertTaskResult> = tokio::task::JoinSet::new();
@@ -267,13 +434,24 @@ impl ExpertKitClient {
             let worker = match assignments.remove(expert_id) {
                 Some(w) => w,
                 None => {
-                    warn!("[Client] Expert {} missing from LPT assignment, falling back to dynamic selection", expert_id);
-                    match self.routing.select_worker_and_mark_inflight(expert_id).await {
+                    warn!(
+                        "[Client] Expert {} missing from LPT assignment, falling back to dynamic selection",
+                        expert_id
+                    );
+                    match self
+                        .routing
+                        .select_worker_and_mark_inflight(expert_id)
+                        .await
+                    {
                         Some(w) => w,
                         None => {
                             let eid = expert_id.clone();
                             jobs.spawn(async move {
-                                ExpertTaskResult::Failed(eid, "No worker available".to_string(), None)
+                                ExpertTaskResult::Failed(
+                                    eid,
+                                    "No worker available".to_string(),
+                                    None,
+                                )
                             });
                             continue;
                         }
@@ -286,8 +464,26 @@ impl ExpertKitClient {
             let seq_positions_clone = seq_positions.clone();
             let transport = self.transport.clone();
             let routing = self.routing.clone();
+            let request_id = trace.request_id;
+            let layer_id = trace.layer_id;
+            let expert_call_id = next_expert_call_id();
+            let expert_timer = {
+                let _entered = trace.layer_span.enter();
+                StageTimer::start(
+                    TraceLabels::new("frontend", "frontend.expert_call")
+                        .path("direct_worker")
+                        .request_id(request_id)
+                        .layer_id(layer_id)
+                        .expert_call_id(expert_call_id)
+                        .expert_id(expert_id.as_str())
+                        .worker(worker.grpc_addr.as_str())
+                        .num_tokens(seq_positions.len()),
+                )
+            };
+            let expert_span = expert_timer.span();
 
             jobs.spawn(async move {
+                let _expert_timer = expert_timer;
                 Self::execute_expert_task(
                     expert_id_clone,
                     seq_positions_clone,
@@ -296,7 +492,11 @@ impl ExpertKitClient {
                     routing,
                     worker,
                     task_create_t,
+                    request_id,
+                    layer_id,
+                    expert_call_id,
                 )
+                .instrument(expert_span)
                 .await
             });
         }
@@ -339,10 +539,7 @@ impl ExpertKitClient {
         // a worker loads the expert.  Retrying on the frontend is wasteful
         // because it re-selects from a potentially stale routing table.
         if !failed_experts.is_empty() {
-            let failed_ids: Vec<String> = failed_experts
-                .into_iter()
-                .map(|(id, _)| id)
-                .collect();
+            let failed_ids: Vec<String> = failed_experts.into_iter().map(|(id, _)| id).collect();
             warn!(
                 "[Client] {} expert tasks failed on direct path, deferring to controller fallback: {:?}",
                 failed_ids.len(),
@@ -376,6 +573,13 @@ impl ExpertKitClient {
         );
 
         let t = std::time::Instant::now();
+        let merge_timer = trace.child_timer(
+            TraceLabels::new("frontend", "frontend.merge")
+                .path("direct_worker")
+                .num_tokens(batch_size),
+        );
+        let merge_span = merge_timer.span();
+        let _merge_entered = merge_span.enter();
         for (expert_id_resp, resp_tensor) in successful_results.iter() {
             let seq_positions = expert_metadata
                 .get(expert_id_resp)
@@ -420,6 +624,7 @@ impl ExpertKitClient {
             "[Client-Time] 🧩 Completed stacking of final output tensors in {:?} μs",
             t.elapsed().as_micros()
         );
+        drop(merge_timer);
 
         Ok(final_output)
     }
@@ -466,12 +671,24 @@ impl ExpertKitClient {
         &self,
         expert_ids: &[Vec<String>],
         hidden_state: &Tensor,
+        trace: &ForwardTrace,
     ) -> Result<Tensor> {
-        let channel = self.controller_channel.as_ref()
+        let channel = self
+            .controller_channel
+            .as_ref()
             .ok_or_else(|| anyhow::anyhow!("Controller channel not established"))?;
 
         // Serialize the hidden state tensor
-        let tensor_bytes = serialize_tch_tensor_2_safetensor(hidden_state)?;
+        let serialize_timer = trace.child_timer(
+            TraceLabels::new("frontend", "frontend.serialize")
+                .path("fallback_controller")
+                .num_tokens(expert_ids.len()),
+        );
+        let serialize_span = serialize_timer.span();
+        let tensor_bytes = async { serialize_tch_tensor_2_safetensor(hidden_state) }
+            .instrument(serialize_span)
+            .await?;
+        drop(serialize_timer);
 
         // Build sequences info for the request
         let sequences: Vec<SequenceInfo> = expert_ids
@@ -499,13 +716,37 @@ impl ExpertKitClient {
             .max_encoding_message_size(max_message_size);
 
         // Send with timeout
-        let response = tokio::time::timeout(self.timeout, client.forward(req))
-            .await
-            .map_err(|_| anyhow::anyhow!("Controller fallback timeout after {:?}", self.timeout))?
-            .map_err(|e| anyhow::anyhow!("Controller fallback gRPC error: {}", e))?;
+        let send_timer = trace.child_timer(
+            TraceLabels::new("frontend", "frontend.send_controller")
+                .path("fallback_controller")
+                .num_tokens(expert_ids.len()),
+        );
+        let send_span = send_timer.span();
+        let response = tokio::time::timeout(
+            self.timeout,
+            async {
+                let mut req = tonic::Request::new(req);
+                inject_current_trace_context(req.metadata_mut());
+                client.forward(req).await
+            }
+            .instrument(send_span),
+        )
+        .await
+        .map_err(|_| anyhow::anyhow!("Controller fallback timeout after {:?}", self.timeout))?
+        .map_err(|e| anyhow::anyhow!("Controller fallback gRPC error: {}", e))?;
+        drop(send_timer);
 
         let output_tensor = response.into_inner().output_tensor;
-        let result = deserialize_safetensor_2_tch_tensor(&output_tensor)?;
+        let deserialize_timer = trace.child_timer(
+            TraceLabels::new("frontend", "frontend.deserialize")
+                .path("fallback_controller")
+                .num_tokens(expert_ids.len()),
+        );
+        let deserialize_span = deserialize_timer.span();
+        let result = async { deserialize_safetensor_2_tch_tensor(&output_tensor) }
+            .instrument(deserialize_span)
+            .await?;
+        drop(deserialize_timer);
 
         info!("[Client] Controller fallback completed successfully");
 
@@ -519,8 +760,14 @@ impl ExpertKitClient {
         expert_ids: Vec<Vec<String>>,
         hidden_state: Tensor,
     ) -> Result<Tensor> {
+        let batch_size = hidden_state.size()[0] as usize;
+        let hidden_dim = hidden_state.size()[1] as usize;
+        let trace = ForwardTrace::start(&expert_ids, batch_size, hidden_dim, "direct_or_fallback");
         // Try direct worker path first (it already has retry logic)
-        match self.forward_expert_tensor(expert_ids.clone(), hidden_state.shallow_clone()).await {
+        match self
+            .forward_expert_tensor_direct(expert_ids.clone(), hidden_state.shallow_clone(), &trace)
+            .await
+        {
             Ok(result) => Ok(result),
             Err(e) => {
                 warn!(
@@ -537,16 +784,16 @@ impl ExpertKitClient {
                 }
 
                 // Fallback to controller as last resort
-                match self.forward_via_controller(&expert_ids, &hidden_state).await {
+                match self
+                    .forward_via_controller(&expert_ids, &hidden_state, &trace)
+                    .await
+                {
                     Ok(result) => {
                         info!("[Client] Controller fallback succeeded");
                         Ok(result)
                     }
                     Err(fallback_err) => {
-                        error!(
-                            "[Client] Controller fallback also failed: {}",
-                            fallback_err
-                        );
+                        error!("[Client] Controller fallback also failed: {}", fallback_err);
                         Err(anyhow::anyhow!(
                             "All paths failed. Direct: {}. Controller: {}",
                             e,

--- a/ek-integration/expertkit-transport-rs/src/lib.rs
+++ b/ek-integration/expertkit-transport-rs/src/lib.rs
@@ -14,11 +14,23 @@ mod utils;
 
 use python::bindings::PyExpertKitClient;
 
+#[pyfunction]
+fn flush_tracing() -> PyResult<()> {
+    observability::flush_tracing().map_err(pyo3::exceptions::PyRuntimeError::new_err)
+}
+
+#[pyfunction]
+fn shutdown_tracing() -> PyResult<()> {
+    observability::shutdown_tracing().map_err(pyo3::exceptions::PyRuntimeError::new_err)
+}
+
 /// ExpertKit Transport Library - Rust FFI Module
 #[pymodule]
 fn _lib(_py: Python, m: &PyModule) -> PyResult<()> {
     // Register the transport client classes
     m.add_class::<PyExpertKitClient>()?;
+    m.add_function(wrap_pyfunction!(flush_tracing, m)?)?;
+    m.add_function(wrap_pyfunction!(shutdown_tracing, m)?)?;
 
     // Add version info
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;

--- a/ek-integration/expertkit-transport-rs/src/lib.rs
+++ b/ek-integration/expertkit-transport-rs/src/lib.rs
@@ -6,6 +6,7 @@ use pyo3::prelude::*;
 
 mod client;
 mod lb;
+mod observability;
 mod python;
 mod routing;
 mod transport;

--- a/ek-integration/expertkit-transport-rs/src/observability.rs
+++ b/ek-integration/expertkit-transport-rs/src/observability.rs
@@ -1,6 +1,6 @@
 use std::{
     sync::{
-        Once,
+        Mutex, Once,
         atomic::{AtomicU64, Ordering},
     },
     time::Instant,
@@ -12,6 +12,7 @@ use opentelemetry::{
 };
 use opentelemetry_sdk::{
     Resource,
+    error::OTelSdkError,
     propagation::{BaggagePropagator, TraceContextPropagator},
     trace::{RandomIdGenerator, Sampler, SdkTracerProvider},
 };
@@ -25,6 +26,7 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 static INIT: Once = Once::new();
+static TRACER_PROVIDER: Mutex<Option<SdkTracerProvider>> = Mutex::new(None);
 static REQUEST_ID: AtomicU64 = AtomicU64::new(1);
 static EXPERT_CALL_ID: AtomicU64 = AtomicU64::new(1);
 static LAYER_ID: AtomicU64 = AtomicU64::new(1);
@@ -166,6 +168,11 @@ pub fn init_tracing() {
             .with_batch_exporter(exporter)
             .build();
         let tracer = provider.tracer("expertkit-transport-rs");
+        if let Ok(mut tracer_provider) = TRACER_PROVIDER.lock() {
+            *tracer_provider = Some(provider.clone());
+        } else {
+            log::warn!("[Tracing] failed to store tracer provider for shutdown");
+        }
         let propagator = TextMapCompositePropagator::new(vec![
             Box::new(BaggagePropagator::new()),
             Box::new(TraceContextPropagator::new()),
@@ -183,6 +190,38 @@ pub fn init_tracing() {
             log::debug!("[Tracing] tracing subscriber already initialized");
         }
     });
+}
+
+pub fn flush_tracing() -> Result<(), String> {
+    let provider = TRACER_PROVIDER
+        .lock()
+        .map_err(|err| format!("failed to lock tracer provider: {err}"))?
+        .clone();
+
+    if let Some(provider) = provider {
+        match provider.force_flush() {
+            Ok(()) | Err(OTelSdkError::AlreadyShutdown) => Ok(()),
+            Err(err) => Err(format!("failed to flush tracing spans: {err}")),
+        }
+    } else {
+        Ok(())
+    }
+}
+
+pub fn shutdown_tracing() -> Result<(), String> {
+    let provider = TRACER_PROVIDER
+        .lock()
+        .map_err(|err| format!("failed to lock tracer provider: {err}"))?
+        .take();
+
+    if let Some(provider) = provider {
+        match provider.shutdown() {
+            Ok(()) | Err(OTelSdkError::AlreadyShutdown) => Ok(()),
+            Err(err) => Err(format!("failed to shutdown tracing: {err}")),
+        }
+    } else {
+        Ok(())
+    }
 }
 
 pub fn next_request_id() -> u64 {

--- a/ek-integration/expertkit-transport-rs/src/observability.rs
+++ b/ek-integration/expertkit-transport-rs/src/observability.rs
@@ -1,0 +1,248 @@
+use std::{
+    sync::{
+        Once,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Instant,
+};
+
+use opentelemetry::propagation::Injector;
+use opentelemetry::{
+    KeyValue, propagation::TextMapCompositePropagator, trace::TracerProvider as _,
+};
+use opentelemetry_sdk::{
+    Resource,
+    propagation::{BaggagePropagator, TraceContextPropagator},
+    trace::{RandomIdGenerator, Sampler, SdkTracerProvider},
+};
+use opentelemetry_semantic_conventions::{
+    SCHEMA_URL,
+    resource::{DEPLOYMENT_ENVIRONMENT_NAME, SERVICE_VERSION},
+};
+use tonic::metadata::MetadataMap;
+use tracing::{Level, Span};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+static INIT: Once = Once::new();
+static REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+static EXPERT_CALL_ID: AtomicU64 = AtomicU64::new(1);
+static LAYER_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Clone)]
+pub struct TraceLabels {
+    pub component: &'static str,
+    pub stage: &'static str,
+    pub path: &'static str,
+    pub request_id: u64,
+    pub layer_id: u64,
+    pub expert_call_id: u64,
+    pub expert_id: String,
+    pub worker: String,
+    pub num_tokens: usize,
+}
+
+impl TraceLabels {
+    pub fn new(component: &'static str, stage: &'static str) -> Self {
+        Self {
+            component,
+            stage,
+            path: "unknown",
+            request_id: 0,
+            layer_id: 0,
+            expert_call_id: 0,
+            expert_id: String::new(),
+            worker: String::new(),
+            num_tokens: 0,
+        }
+    }
+
+    pub fn path(mut self, path: &'static str) -> Self {
+        self.path = path;
+        self
+    }
+
+    pub fn request_id(mut self, request_id: u64) -> Self {
+        self.request_id = request_id;
+        self
+    }
+
+    pub fn layer_id(mut self, layer_id: u64) -> Self {
+        self.layer_id = layer_id;
+        self
+    }
+
+    pub fn expert_call_id(mut self, expert_call_id: u64) -> Self {
+        self.expert_call_id = expert_call_id;
+        self
+    }
+
+    pub fn expert_id(mut self, expert_id: impl Into<String>) -> Self {
+        self.expert_id = expert_id.into();
+        self
+    }
+
+    pub fn worker(mut self, worker: impl Into<String>) -> Self {
+        self.worker = worker.into();
+        self
+    }
+
+    pub fn num_tokens(mut self, num_tokens: usize) -> Self {
+        self.num_tokens = num_tokens;
+        self
+    }
+}
+
+pub struct StageTimer {
+    labels: TraceLabels,
+    start: Instant,
+    span: Span,
+}
+
+impl StageTimer {
+    pub fn start(labels: TraceLabels) -> Self {
+        let span = trace_span(&labels);
+        Self {
+            labels,
+            start: Instant::now(),
+            span,
+        }
+    }
+
+    pub fn span(&self) -> Span {
+        self.span.clone()
+    }
+}
+
+impl Drop for StageTimer {
+    fn drop(&mut self) {
+        let elapsed_us = self.start.elapsed().as_micros() as u64;
+        let labels = &self.labels;
+        self.span.in_scope(|| {
+            tracing::info!(
+                elapsed_us,
+                component = labels.component,
+                stage = labels.stage,
+                path = labels.path,
+                request_id = labels.request_id,
+                layer_id = labels.layer_id,
+                expert_call_id = labels.expert_call_id,
+                expert_id = labels.expert_id.as_str(),
+                worker = labels.worker.as_str(),
+                num_tokens = labels.num_tokens,
+                "expert-kit trace stage done",
+            );
+        });
+    }
+}
+
+pub fn init_tracing() {
+    INIT.call_once(|| {
+        let exporter = match opentelemetry_otlp::SpanExporter::builder()
+            .with_tonic()
+            .build()
+        {
+            Ok(exporter) => exporter,
+            Err(err) => {
+                log::warn!("[Tracing] failed to initialize OTLP exporter: {err}");
+                return;
+            }
+        };
+
+        let resource = Resource::builder()
+            .with_service_name("frontend")
+            .with_schema_url(
+                [
+                    KeyValue::new(SERVICE_VERSION, env!("CARGO_PKG_VERSION")),
+                    KeyValue::new(DEPLOYMENT_ENVIRONMENT_NAME, "develop"),
+                ],
+                SCHEMA_URL,
+            )
+            .build();
+        let provider = SdkTracerProvider::builder()
+            .with_sampler(Sampler::AlwaysOn)
+            .with_id_generator(RandomIdGenerator::default())
+            .with_resource(resource)
+            .with_batch_exporter(exporter)
+            .build();
+        let tracer = provider.tracer("expertkit-transport-rs");
+        let propagator = TextMapCompositePropagator::new(vec![
+            Box::new(BaggagePropagator::new()),
+            Box::new(TraceContextPropagator::new()),
+        ]);
+        opentelemetry::global::set_text_map_propagator(propagator);
+
+        if tracing_subscriber::registry()
+            .with(tracing_subscriber::filter::LevelFilter::from_level(
+                Level::INFO,
+            ))
+            .with(tracing_opentelemetry::layer().with_tracer(tracer))
+            .try_init()
+            .is_err()
+        {
+            log::debug!("[Tracing] tracing subscriber already initialized");
+        }
+    });
+}
+
+pub fn next_request_id() -> u64 {
+    REQUEST_ID.fetch_add(1, Ordering::SeqCst)
+}
+
+pub fn next_expert_call_id() -> u64 {
+    EXPERT_CALL_ID.fetch_add(1, Ordering::SeqCst)
+}
+
+pub fn next_layer_id() -> u64 {
+    LAYER_ID.fetch_add(1, Ordering::SeqCst)
+}
+
+pub fn trace_span(labels: &TraceLabels) -> Span {
+    tracing::span!(
+        Level::INFO,
+        "ek.trace",
+        otel.name = labels.stage,
+        component = labels.component,
+        stage = labels.stage,
+        path = labels.path,
+        request_id = labels.request_id,
+        layer_id = labels.layer_id,
+        expert_call_id = labels.expert_call_id,
+        expert_id = labels.expert_id.as_str(),
+        worker = labels.worker.as_str(),
+        num_tokens = labels.num_tokens,
+    )
+}
+
+pub fn inject_current_trace_context(metadata: &mut MetadataMap) {
+    let ctx = Span::current().context();
+    let mut injector = MetadataInjector(metadata);
+    opentelemetry::global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(&ctx, &mut injector);
+    });
+}
+
+pub fn infer_layer_id(expert_ids: &[Vec<String>], fallback: u64) -> u64 {
+    expert_ids
+        .iter()
+        .flatten()
+        .find_map(|expert_id| {
+            let marker = expert_id.rfind("/l")?;
+            let after_layer = &expert_id[marker + 2..];
+            let end = after_layer.find("-e").unwrap_or(after_layer.len());
+            after_layer[..end].parse::<u64>().ok()
+        })
+        .unwrap_or(fallback)
+}
+
+struct MetadataInjector<'a>(&'a mut MetadataMap);
+
+impl Injector for MetadataInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        if let Ok(key) = tonic::metadata::MetadataKey::from_bytes(key.as_bytes())
+            && let Ok(value) = value.parse()
+        {
+            self.0.insert(key, value);
+        }
+    }
+}

--- a/ek-integration/expertkit-transport-rs/src/python/bindings.rs
+++ b/ek-integration/expertkit-transport-rs/src/python/bindings.rs
@@ -2,7 +2,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyAny;
 
 use crate::client::ExpertKitClient as RustExpertKitClient;
-use crate::observability::init_tracing;
+use crate::observability::{flush_tracing, init_tracing};
 use crate::utils::{TensorMetadata, pytorch_to_tch_tensor, tch_to_pytorch_tensor};
 
 const DEFAULT_THREAD_NUM: usize = 16;
@@ -23,10 +23,6 @@ pub struct PyExpertKitClient {
 impl PyExpertKitClient {
     #[new]
     fn new(controller_addr: String, timeout_sec: Option<f64>) -> PyResult<Self> {
-        if env_logger::try_init().is_ok() {
-            log::info!("Logger initialized");
-        }
-
         let timeout = timeout_sec.unwrap_or(DEFAULT_TIMEOUT_SEC);
 
         // Create ONE shared Tokio runtime for all requests
@@ -43,6 +39,9 @@ impl PyExpertKitClient {
         {
             let _entered = runtime.enter();
             init_tracing();
+        }
+        if env_logger::try_init().is_ok() {
+            log::info!("Logger initialized");
         }
 
         Ok(Self {
@@ -176,5 +175,20 @@ impl PyExpertKitClient {
                 .block_on(async { client.refresh_routing().await })
                 .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
         })
+    }
+
+    fn close(&mut self) -> PyResult<()> {
+        flush_tracing().map_err(pyo3::exceptions::PyRuntimeError::new_err)?;
+        self.client = None;
+        self.runtime = None;
+        Ok(())
+    }
+}
+
+impl Drop for PyExpertKitClient {
+    fn drop(&mut self) {
+        if let Err(err) = flush_tracing() {
+            log::warn!("[Tracing] failed to flush tracing during client drop: {err}");
+        }
     }
 }

--- a/ek-integration/expertkit-transport-rs/src/python/bindings.rs
+++ b/ek-integration/expertkit-transport-rs/src/python/bindings.rs
@@ -2,6 +2,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyAny;
 
 use crate::client::ExpertKitClient as RustExpertKitClient;
+use crate::observability::init_tracing;
 use crate::utils::{TensorMetadata, pytorch_to_tch_tensor, tch_to_pytorch_tensor};
 
 const DEFAULT_THREAD_NUM: usize = 16;
@@ -39,6 +40,10 @@ impl PyExpertKitClient {
                     e
                 ))
             })?;
+        {
+            let _entered = runtime.enter();
+            init_tracing();
+        }
 
         Ok(Self {
             client: Some(RustExpertKitClient::new(controller_addr, timeout)),
@@ -109,7 +114,9 @@ impl PyExpertKitClient {
                 .block_on(async {
                     if use_fallback {
                         // Use fallback version for maximum resilience
-                        client.forward_expert_tensor_with_fallback(expert_ids, input_tensor).await
+                        client
+                            .forward_expert_tensor_with_fallback(expert_ids, input_tensor)
+                            .await
                     } else {
                         // Direct path only (still has retry logic)
                         client.forward_expert_tensor(expert_ids, input_tensor).await

--- a/ek-integration/expertkit-transport-rs/src/transport/grpc.rs
+++ b/ek-integration/expertkit-transport-rs/src/transport/grpc.rs
@@ -29,6 +29,8 @@ pub mod proto {
 
 use proto::ek::worker::v1::{ForwardReq, computation_service_client::ComputationServiceClient};
 
+use crate::observability::inject_current_trace_context;
+
 /// Connect timeout for establishing new gRPC connections (3 seconds)
 const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 
@@ -92,7 +94,10 @@ impl GrpcTransport {
     async fn invalidate_channel(&self, endpoint: &str) {
         let mut channels = self.channels.write().await;
         if channels.remove(endpoint).is_some() {
-            warn!("[GrpcTransport] Invalidated cached channel for {}", endpoint);
+            warn!(
+                "[GrpcTransport] Invalidated cached channel for {}",
+                endpoint
+            );
         }
     }
 }
@@ -148,6 +153,8 @@ impl Transport for GrpcTransport {
             );
 
             // Send with timeout
+            let mut grpc_req = tonic::Request::new(grpc_req);
+            inject_current_trace_context(grpc_req.metadata_mut());
             let result = tokio::time::timeout(self.timeout, client.forward(grpc_req)).await;
 
             match result {

--- a/ek-integration/expertkit-transport-rs/src/transport/mod.rs
+++ b/ek-integration/expertkit-transport-rs/src/transport/mod.rs
@@ -25,6 +25,9 @@ pub struct ExpertRequest {
     pub expert_id: String,
     pub tensor_data: Vec<u8>, // Safetensors blob containing batched sequences
     pub num_sequences: usize, // Number of sequences in this batch
+    pub request_id: u64,
+    pub layer_id: u64,
+    pub expert_call_id: u64,
 }
 
 impl ExpertRequest {
@@ -34,7 +37,22 @@ impl ExpertRequest {
             expert_id,
             tensor_data,
             num_sequences,
+            request_id: 0,
+            layer_id: 0,
+            expert_call_id: 0,
         }
+    }
+
+    pub fn with_trace_context(
+        mut self,
+        request_id: u64,
+        layer_id: u64,
+        expert_call_id: u64,
+    ) -> Self {
+        self.request_id = request_id;
+        self.layer_id = layer_id;
+        self.expert_call_id = expert_call_id;
+        self
     }
 }
 

--- a/ek-integration/expertkit_torch/expertkit_torch/grpc_client_new.py
+++ b/ek-integration/expertkit_torch/expertkit_torch/grpc_client_new.py
@@ -6,9 +6,14 @@ import safetensors.torch
 logger = logging.getLogger(__name__)
 
 try:
-    from expertkit_transport import ExpertKitClient as RustExpertKitClient
+    from expertkit_transport import (
+        ExpertKitClient as RustExpertKitClient,
+        flush_tracing as _flush_tracing,
+    )
     RUST_CLIENT_AVAILABLE = True
 except ImportError:
+    RustExpertKitClient = None
+    _flush_tracing = None
     RUST_CLIENT_AVAILABLE = False
     logger.warning("Rust client not available - ExpertKitClient will not work")
 
@@ -37,6 +42,7 @@ class ExpertKitClient:
 
         # Create Rust client and connect immediately
         self.rust_client = RustExpertKitClient(controller_addr, timeout_sec)
+        self._closed = False
         self.rust_client.connect()
 
         logger.info(
@@ -60,6 +66,8 @@ class ExpertKitClient:
         logger.debug(
             f"Sending batch_size={len(expert_ids)}"
         )
+        if self._closed or self.rust_client is None:
+            raise RuntimeError("ExpertKitClient is closed")
 
         # Pass tensor directly to Rust
         # Rust accesses tensor memory directly via pointer
@@ -68,3 +76,24 @@ class ExpertKitClient:
         logger.debug(f"Received output shape: {output.shape}")
 
         return output
+
+    def close(self) -> None:
+        """Flush frontend tracing spans before releasing the Rust client."""
+        if getattr(self, "_closed", True):
+            return
+
+        try:
+            rust_client = getattr(self, "rust_client", None)
+            if rust_client is not None and hasattr(rust_client, "close"):
+                rust_client.close()
+            elif _flush_tracing is not None:
+                _flush_tracing()
+        finally:
+            self.rust_client = None
+            self._closed = True
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary

This PR fixes frontend tracing span loss in the Rust transport Python client.

Previously, frontend spans could be dropped when the Python process exited before the OpenTelemetry batch exporter finished sending spans to Jaeger. In some runs, worker spans were visible, but the frontend root/request tree was missing or incomplete.

**missing frontend spans**
<img width="2908" height="1540" alt="48a762c6fd4ad8fcfc28c5b3f75046d0" src="https://github.com/user-attachments/assets/97e51319-fd08-428d-a670-96630382884b" />


This PR adds explicit tracing flush/shutdown support and wires it into the Python client lifecycle.

## Changes

- Store the frontend OpenTelemetry tracer provider so it can be flushed or shut down explicitly.
- Expose `flush_tracing()` and `shutdown_tracing()` from `expertkit_transport`.
- Register `shutdown_tracing()` with Python `atexit`.
- Add `ExpertKitClient.close()` and `__del__()` cleanup in `grpc_client_new.py`.
- Flush tracing spans before releasing the Rust transport client/runtime.
- Initialize frontend tracing before `env_logger` so the OpenTelemetry tracing subscriber is correctly installed.

## Validation
Environment:

- Model: `Qwen3-30B-A3B`
- Worker devices: `worker-1=cuda0`, `worker-2=cuda0`
- Jaeger: `http://127.0.0.1:16686`

### 1.Validated on the Qwen3-30B-A3B direct worker / p2p path.


- Trace ID: `0a6cab222ea6b9a0c8f4bb2fbc970f40`

Test command:

```bash
curl -s http://127.0.0.1:16686/api/traces/0a6cab222ea6b9a0c8f4bb2fbc970f40 > trace.json

python3 - <<'PY'
import json
import collections

with open("trace.json") as f:
    data = json.load(f)["data"][0]

spans = data["spans"]
processes = data["processes"]

service_by_pid = {pid: proc["serviceName"] for pid, proc in processes.items()}
by_service = collections.Counter(service_by_pid[span["processID"]] for span in spans)
by_operation = collections.Counter(span["operationName"] for span in spans)

print("trace_id:", data["traceID"])
print("total_spans:", len(spans))
print("by_service:", dict(by_service))
print("frontend.send_worker:", by_operation.get("frontend.send_worker", 0))
print("worker.forward:", by_operation.get("worker.forward", 0))
print("worker.compute:", by_operation.get("worker.compute", 0))
print(
    "matched:",
    by_operation.get("frontend.send_worker", 0)
    == by_operation.get("worker.forward", 0)
    == by_operation.get("worker.compute", 0)
)
PY
```

**result**

trace_id: 0a6cab222ea6b9a0c8f4bb2fbc970f40
total_spans: 786
by_service: {'frontend': 325, 'worker': 461}
frontend.send_worker: 64
worker.forward: 64
worker.compute: 64
matched: True

**trace 0a6cab222ea6b9a0c8f4bb2fbc970f40** 
<img width="1678" height="743" alt="image" src="https://github.com/user-attachments/assets/d5cd5865-4f2b-4f47-ae00-0344f07b9509" />
**some request traces**
<img width="1679" height="742" alt="image" src="https://github.com/user-attachments/assets/cb20c970-00aa-46e9-9271-651639fad023" />

### 2.Validated on the Qwen3-30B-A3B controller -> worker path.

- Trace ID: `331424de4f8659fdaad83f3058c7961e`

Test command:

```bash
TRACE_ID=331424de4f8659fdaad83f3058c7961e
curl -s http://127.0.0.1:16686/api/traces/$TRACE_ID > controller_trace.json

python3 - <<'PY'
import json, collections

with open("controller_trace.json") as f:
    data = json.load(f)["data"][0]

spans = data["spans"]
processes = data["processes"]

service_by_pid = {pid: proc["serviceName"] for pid, proc in processes.items()}
by_service = collections.Counter(service_by_pid[span["processID"]] for span in spans)
by_operation = collections.Counter(span["operationName"] for span in spans)

print("trace_id:", data["traceID"])
print("total_spans:", len(spans))
print("by_service:", dict(by_service))
print("controller.send_worker:", by_operation.get("controller.send_worker", 0))
print("worker.forward:", by_operation.get("worker.forward", 0))
print("worker.compute:", by_operation.get("worker.compute", 0))
print(
    "matched:",
    by_operation.get("controller.send_worker", 0)
    == by_operation.get("worker.forward", 0)
    == by_operation.get("worker.compute", 0)
)
PY
```
**result**

trace_id: 331424de4f8659fdaad83f3058c7961e
total_spans: 976
by_service: {'worker': 460, 'controller': 516}
controller.send_worker: 64
worker.forward: 64
worker.compute: 64
matched: True

**trace 331424de4f8659fdaad83f3058c7961e** 
<img width="1679" height="835" alt="image" src="https://github.com/user-attachments/assets/39537dd9-8dff-47bd-aefd-6283d8c7a524" />
**some controller-worker request**
<img width="1676" height="834" alt="image" src="https://github.com/user-attachments/assets/d98f5fc6-ffd6-42d6-bac1-21fe5e4ded4a" />

Related to #131