### PR TITLE
trace direct grpc and shm worker paths

### DIFF
--- a/ek-integration/expertkit_torch/expertkit_torch/benchmark/runner.py
+++ b/ek-integration/expertkit_torch/expertkit_torch/benchmark/runner.py
@@ -9,6 +9,7 @@ from dataclasses import asdict, dataclass
 from typing import Any
 
 import torch
+from expertkit_transport import frontend_request_span
 
 _FIXED_INPUT_TEXT = "Expert Kit routed mixture of experts benchmark input"
 
@@ -167,6 +168,31 @@ def _synchronize(device: torch.device) -> None:
 
 
 def _measure_generation(
+    model: Any,
+    tokenizer: Any,
+    input_ids: torch.Tensor,
+    *,
+    output_length: int,
+    clock: Callable[[], float],
+    synchronize: Callable[[torch.device], None],
+) -> RunMetrics:
+    attributes = {
+        "expertkit.batch_size": int(input_ids.shape[0]),
+        "expertkit.input_length": int(input_ids.shape[1]),
+        "expertkit.output_length": output_length,
+    }
+    with frontend_request_span(attributes=attributes):
+        return _measure_generation_body(
+            model,
+            tokenizer,
+            input_ids,
+            output_length=output_length,
+            clock=clock,
+            synchronize=synchronize,
+        )
+
+
+def _measure_generation_body(
     model: Any,
     tokenizer: Any,
     input_ids: torch.Tensor,

--- a/ek-integration/expertkit_torch/expertkit_torch/client.py
+++ b/ek-integration/expertkit_torch/expertkit_torch/client.py
@@ -6,7 +6,12 @@ import math
 import threading
 
 import torch
-from expertkit_transport import BlockingRoutedMoEClient, validate_and_convert_routing
+from expertkit_transport import (
+    BlockingRoutedMoEClient,
+    flush_tracing,
+    validate_and_convert_routing,
+)
+from expertkit_transport.tracing import get_frontend_tracer, trace_span
 
 
 class RoutedMoEClient:
@@ -55,6 +60,7 @@ class RoutedMoEClient:
         self._top_k = top_k
         self._timeout_seconds = timeout_seconds
         self._transport: BlockingRoutedMoEClient | None = None
+        self._tracer = get_frontend_tracer()
         self._device: torch.device | None = None
         self._dtype: torch.dtype | None = None
         self._lock = threading.Lock()
@@ -125,22 +131,29 @@ class RoutedMoEClient:
         ):
             raise ValueError("all Routed-MoE tensors must use the activation device")
 
-        encoded_experts, fp32_weights, distinct_expert_ids = validate_and_convert_routing(
-            expert_ids,
-            routing_weights,
-            experts_per_layer=self._experts_per_layer,
-        )
-        self.start(device=hidden_states.device, dtype=hidden_states.dtype)
-        transport = self._transport
-        assert transport is not None
-        return transport.execute(
-            layer_id=layer_id,
-            hidden_states=hidden_states,
-            expert_ids=encoded_experts,
-            routing_weights=fp32_weights,
-            distinct_expert_ids=distinct_expert_ids,
-            timeout_seconds=self._timeout_seconds,
-        )
+        attributes = {
+            "expertkit.layer_id": layer_id,
+            "expertkit.token_count": int(hidden_states.shape[0]),
+            "expertkit.assignment_count": int(hidden_states.shape[0]) * self._top_k,
+        }
+        with trace_span(self._tracer, "frontend.layer", attributes=attributes):
+            with trace_span(self._tracer, "frontend.decompose", attributes=attributes):
+                encoded_experts, fp32_weights, distinct_expert_ids = validate_and_convert_routing(
+                    expert_ids,
+                    routing_weights,
+                    experts_per_layer=self._experts_per_layer,
+                )
+            self.start(device=hidden_states.device, dtype=hidden_states.dtype)
+            transport = self._transport
+            assert transport is not None
+            return transport.execute(
+                layer_id=layer_id,
+                hidden_states=hidden_states,
+                expert_ids=encoded_experts,
+                routing_weights=fp32_weights,
+                distinct_expert_ids=distinct_expert_ids,
+                timeout_seconds=self._timeout_seconds,
+            )
 
     def close(self) -> None:
         """Close Transport resources; repeated calls are safe."""
@@ -151,5 +164,8 @@ class RoutedMoEClient:
             self._closed = True
             transport = self._transport
             self._transport = None
-        if transport is not None:
-            transport.close()
+        try:
+            if transport is not None:
+                transport.close()
+        finally:
+            flush_tracing()

--- a/ek-integration/expertkit_torch/tests/test_benchmark.py
+++ b/ek-integration/expertkit_torch/tests/test_benchmark.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 import torch
 
+from expertkit_torch.benchmark import runner
 from expertkit_torch.benchmark.runner import (
     BatchBenchmark,
     RunMetrics,
@@ -97,6 +98,49 @@ def test_benchmark_runs_prefill_and_cached_decode_for_each_batch() -> None:
     assert first.output_tps == 2
     assert first.generated_token_ids == ((0, 0, 0, 0),)
     assert first.generated_text == ("0 0 0 0",)
+
+
+def test_each_generation_has_one_request_root(monkeypatch) -> None:
+    roots: list[dict[str, int]] = []
+
+    class RequestSpan:
+        def __init__(self, attributes: dict[str, int]) -> None:
+            self.attributes = attributes
+
+        def __enter__(self) -> None:
+            roots.append(self.attributes)
+
+        def __exit__(self, *_: object) -> None:
+            return None
+
+    monkeypatch.setattr(
+        runner,
+        "frontend_request_span",
+        lambda *, attributes: RequestSpan(dict(attributes)),
+    )
+
+    run_benchmark(
+        FakeModel(),
+        FakeTokenizer(),
+        model_type="qwen3_moe",
+        mode="expertkit",
+        batch_sizes=(2,),
+        input_length=3,
+        output_length=2,
+        warmup_runs=1,
+        measured_runs=2,
+        device="cpu",
+        clock=IncrementingClock(),
+        synchronize=lambda _: None,
+    )
+
+    assert roots == [
+        {
+            "expertkit.batch_size": 2,
+            "expertkit.input_length": 3,
+            "expertkit.output_length": 2,
+        }
+    ] * 3
 
 
 def test_output_length_one_has_no_decode_phase() -> None:

--- a/ek-integration/expertkit_torch/tests/test_client.py
+++ b/ek-integration/expertkit_torch/tests/test_client.py
@@ -72,6 +72,25 @@ def test_forwards_final_assignments_once_with_wire_dtypes(monkeypatch) -> None:
     assert transport.closed is True
 
 
+def test_close_flushes_frontend_spans_after_transport_cleanup(monkeypatch) -> None:
+    events: list[str] = []
+
+    class OrderedTransport(FakeTransport):
+        def close(self) -> None:
+            events.append("transport.close")
+            super().close()
+
+    monkeypatch.setattr(client, "BlockingRoutedMoEClient", OrderedTransport)
+    monkeypatch.setattr(client, "flush_tracing", lambda: events.append("tracing.flush"))
+    routed = routed_client()
+    routed.start(device="cpu", dtype=torch.float32)
+
+    routed.close()
+    routed.close()
+
+    assert events == ["transport.close", "tracing.flush"]
+
+
 def test_reuses_one_transport_and_rejects_a_dtype_change(monkeypatch) -> None:
     FakeTransport.instances.clear()
     monkeypatch.setattr(client, "BlockingRoutedMoEClient", FakeTransport)

--- a/ek-transport/pyproject.toml
+++ b/ek-transport/pyproject.toml
@@ -15,6 +15,12 @@ dependencies = [
     "torch==2.11.0",
 ]
 
+[project.optional-dependencies]
+observability = [
+    "opentelemetry-exporter-otlp-proto-grpc==1.39.1",
+    "opentelemetry-sdk==1.39.1",
+]
+
 [tool.uv.sources]
 expertkit-proto = { workspace = true }
 

--- a/ek-transport/src/expertkit_transport/__init__.py
+++ b/ek-transport/src/expertkit_transport/__init__.py
@@ -4,6 +4,7 @@ from expertkit_transport.batches import RoutedLayerBatch
 from expertkit_transport.client import BlockingRoutedMoEClient, RoutedMoEClient
 from expertkit_transport.errors import TransportError, TransportErrorCode
 from expertkit_transport.routing.validation import validate_and_convert_routing
+from expertkit_transport.tracing import flush_tracing, frontend_request_span, shutdown_tracing
 
 __all__ = [
     "BlockingRoutedMoEClient",
@@ -11,5 +12,8 @@ __all__ = [
     "RoutedMoEClient",
     "TransportError",
     "TransportErrorCode",
+    "flush_tracing",
+    "frontend_request_span",
+    "shutdown_tracing",
     "validate_and_convert_routing",
 ]

--- a/ek-transport/src/expertkit_transport/client.py
+++ b/ek-transport/src/expertkit_transport/client.py
@@ -16,6 +16,7 @@ from expertkit_transport.controller.instance import resolve_default_instance
 from expertkit_transport.controller.topology import ControllerTopologyWatcher
 from expertkit_transport.errors import TransportError, TransportErrorCode
 from expertkit_transport.routing import RoundRobinSelector, execute_routed_layer
+from expertkit_transport.tracing import Tracer, get_frontend_tracer
 
 _RESULT_GRACE_SECONDS = 0.1
 
@@ -78,6 +79,7 @@ class RoutedMoEClient:
         self._clock = clock
         self._topology: ControllerTopologyWatcher | None = None
         self._selector = RoundRobinSelector()
+        self._tracer: Tracer | None = get_frontend_tracer()
         self._started = False
         self._closed = False
 
@@ -172,6 +174,7 @@ class RoutedMoEClient:
             monotonic_deadline=monotonic_deadline,
             same_worker_retry_delay_seconds=self._same_worker_retry_delay_seconds,
             clock=self._clock,
+            tracer=self._tracer,
         )
 
     async def close(self) -> None:

--- a/ek-transport/src/expertkit_transport/routing/dispatch.py
+++ b/ek-transport/src/expertkit_transport/routing/dispatch.py
@@ -12,6 +12,7 @@ from expertkit_transport.buffers import OutputPool
 from expertkit_transport.errors import TransportError
 from expertkit_transport.routing.grouping import WorkerBatchPlan
 from expertkit_transport.routing.topology import WorkerIdentity
+from expertkit_transport.tracing import Tracer, trace_span
 
 
 @dataclass(frozen=True, slots=True)
@@ -47,24 +48,33 @@ async def _dispatch_plan(
     pool: OutputPool,
     accumulator: torch.Tensor,
     monotonic_deadline: float,
+    *,
+    tracer: Tracer | None,
+    attempt: int,
 ) -> FailedWorkerBatch | None:
     try:
-        async with pool.lease(monotonic_deadline=monotonic_deadline) as lease:
-            await plan.target.transport.execute(
-                plan.batch,
-                lease.tensor[: plan.batch.token_count],
-                monotonic_deadline=monotonic_deadline,
-            )
-            partial = lease.tensor[: plan.batch.token_count]
-            token_indices = plan.batch.token_indices
-            if token_indices is None:
-                token_indices = torch.arange(
-                    plan.batch.token_count,
-                    dtype=torch.int64,
-                    device=accumulator.device,
+        with trace_span(
+            tracer,
+            "frontend.worker_batch",
+            attributes=_plan_attributes(plan, attempt),
+        ):
+            async with pool.lease(monotonic_deadline=monotonic_deadline) as lease:
+                await plan.target.transport.execute(
+                    plan.batch,
+                    lease.tensor[: plan.batch.token_count],
+                    monotonic_deadline=monotonic_deadline,
                 )
-            accumulator.index_add_(0, token_indices, partial.to(torch.float32))
-            lease.mark_consumed()
+                partial = lease.tensor[: plan.batch.token_count]
+                token_indices = plan.batch.token_indices
+                if token_indices is None:
+                    token_indices = torch.arange(
+                        plan.batch.token_count,
+                        dtype=torch.int64,
+                        device=accumulator.device,
+                    )
+                with trace_span(tracer, "frontend.merge"):
+                    accumulator.index_add_(0, token_indices, partial.to(torch.float32))
+                lease.mark_consumed()
     except TransportError as error:
         return FailedWorkerBatch(plan=plan, error=error)
     return None
@@ -74,6 +84,8 @@ async def dispatch_complete_plan(
     plan: WorkerBatchPlan,
     *,
     monotonic_deadline: float,
+    tracer: Tracer | None = None,
+    attempt: int = 1,
 ) -> tuple[torch.Tensor | None, FailedWorkerBatch | None]:
     """Return one complete Worker result without FP32 scatter aggregation."""
 
@@ -82,11 +94,16 @@ async def dispatch_complete_plan(
         raise ValueError("a complete Worker plan must select every source token")
     result = torch.empty_like(batch.hidden_states)
     try:
-        await plan.target.transport.execute(
-            batch,
-            result,
-            monotonic_deadline=monotonic_deadline,
-        )
+        with trace_span(
+            tracer,
+            "frontend.worker_batch",
+            attributes=_plan_attributes(plan, attempt),
+        ):
+            await plan.target.transport.execute(
+                batch,
+                result,
+                monotonic_deadline=monotonic_deadline,
+            )
     except TransportError as error:
         return None, FailedWorkerBatch(plan=plan, error=error)
     return result, None
@@ -98,6 +115,8 @@ async def dispatch_once(
     accumulator: torch.Tensor,
     *,
     monotonic_deadline: float,
+    tracer: Tracer | None = None,
+    attempt: int = 1,
 ) -> tuple[FailedWorkerBatch, ...]:
     """Dispatch every physical batch once and add successes exactly once.
 
@@ -129,9 +148,28 @@ async def dispatch_once(
             pool,
             accumulator,
             monotonic_deadline,
+            tracer=tracer,
+            attempt=attempt,
         )
 
     async with asyncio.TaskGroup() as tasks:
         for index, plan in enumerate(plans):
             tasks.create_task(run(index, plan))
     return tuple(failure for failure in failures if failure is not None)
+
+
+def _plan_attributes(plan: WorkerBatchPlan, attempt: int) -> dict[str, str | int]:
+    batch = plan.batch
+    identity = plan.target.identity
+    return {
+        "expertkit.instance_id": batch.instance_id,
+        "expertkit.layer_id": batch.layer_id,
+        "expertkit.topology_version": batch.topology_version,
+        "expertkit.token_count": batch.token_count,
+        "expertkit.assignment_count": batch.token_count * batch.top_k,
+        "expertkit.expert_ids": ",".join(str(expert_id) for expert_id in batch.distinct_expert_ids),
+        "expertkit.worker_id": identity.worker_id,
+        "expertkit.worker_start_id": identity.start_id,
+        "expertkit.transport": plan.target.transport.transport_name,
+        "expertkit.attempt": attempt,
+    }

--- a/ek-transport/src/expertkit_transport/routing/execute.py
+++ b/ek-transport/src/expertkit_transport/routing/execute.py
@@ -27,6 +27,7 @@ from expertkit_transport.routing.topology import (
     TopologyProvider,
     WorkerIdentity,
 )
+from expertkit_transport.tracing import Tracer, trace_span
 
 _DEFAULT_SAME_WORKER_RETRY_DELAY_SECONDS = 0.001
 
@@ -142,6 +143,7 @@ async def execute_routed_layer(
     same_worker_retry_delay_seconds: float = _DEFAULT_SAME_WORKER_RETRY_DELAY_SECONDS,
     clock: Callable[[], float] = time.monotonic,
     sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    tracer: Tracer | None = None,
 ) -> torch.Tensor:
     """Return one aggregated Routed-MoE layer result.
 
@@ -181,8 +183,18 @@ async def execute_routed_layer(
     if monotonic_deadline - clock() <= 0:
         raise _deadline_error("the Routed layer deadline expired before dispatch")
 
-    snapshot = topology.current(batch.instance_id)
-    plans = group_worker_batches(batch, snapshot, selector)
+    with trace_span(
+        tracer,
+        "frontend.route",
+        attributes={
+            "expertkit.instance_id": batch.instance_id,
+            "expertkit.layer_id": batch.layer_id,
+            "expertkit.token_count": batch.token_count,
+            "expertkit.assignment_count": batch.token_count * batch.top_k,
+        },
+    ):
+        snapshot = topology.current(batch.instance_id)
+        plans = group_worker_batches(batch, snapshot, selector)
     if not plans:
         return torch.zeros_like(batch.hidden_states)
 
@@ -191,6 +203,8 @@ async def execute_routed_layer(
         direct_result, direct_failure = await dispatch_complete_plan(
             plans[0],
             monotonic_deadline=monotonic_deadline,
+            tracer=tracer,
+            attempt=1,
         )
         if direct_failure is None:
             assert direct_result is not None
@@ -207,6 +221,8 @@ async def execute_routed_layer(
             pools,
             accumulator,
             monotonic_deadline=monotonic_deadline,
+            tracer=tracer,
+            attempt=1,
         )
     if not failures:
         assert accumulator is not None
@@ -259,6 +275,8 @@ async def execute_routed_layer(
         pools,
         accumulator,
         monotonic_deadline=monotonic_deadline,
+        tracer=tracer,
+        attempt=2,
     )
     if retry_failures:
         raise retry_failures[-1].error

--- a/ek-transport/src/expertkit_transport/tracing.py
+++ b/ek-transport/src/expertkit_transport/tracing.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import atexit
+import os
+import threading
 from collections.abc import Mapping
-from contextlib import AbstractContextManager
-from typing import Protocol
+from contextlib import AbstractContextManager, nullcontext
+from typing import Any, Protocol
 
 type TraceAttribute = str | bool | int | float
 type TraceContext = object
@@ -49,3 +52,203 @@ class Tracer(Protocol):
         attributes: Mapping[str, TraceAttribute] | None = None,
     ) -> AbstractContextManager[TraceSpan]:
         """Start a span and make it current for the context-manager lifetime."""
+
+
+class _OpenTelemetryTracer:
+    """Adapt an OpenTelemetry tracer to the local dependency-free Protocol."""
+
+    def __init__(self, tracer: Any, context_api: Any, trace_api: Any) -> None:
+        self._tracer = tracer
+        self._context_api = context_api
+        self._trace_api = trace_api
+
+    def current_span_is_recording(self) -> bool:
+        return bool(self._trace_api.get_current_span().is_recording())
+
+    def capture_context(self) -> TraceContext:
+        return self._context_api.get_current()
+
+    def start_span(
+        self,
+        name: str,
+        *,
+        context: TraceContext | None = None,
+        attributes: Mapping[str, TraceAttribute] | None = None,
+    ) -> TraceSpan:
+        return self._tracer.start_span(
+            name,
+            context=context,
+            attributes=None if attributes is None else dict(attributes),
+        )
+
+    def start_as_current_span(
+        self,
+        name: str,
+        *,
+        context: TraceContext | None = None,
+        attributes: Mapping[str, TraceAttribute] | None = None,
+    ) -> AbstractContextManager[TraceSpan]:
+        return self._tracer.start_as_current_span(
+            name,
+            context=context,
+            attributes=None if attributes is None else dict(attributes),
+        )
+
+
+_TRACING_LOCK = threading.Lock()
+_TRACER_PROVIDER: Any | None = None
+_TRACER: Tracer | None = None
+_TRACING_SHUT_DOWN = False
+
+
+def initialize_frontend_tracing() -> Tracer | None:
+    """Initialize optional Frontend OpenTelemetry export from OTEL env vars."""
+
+    global _TRACER_PROVIDER, _TRACER, _TRACING_SHUT_DOWN
+    with _TRACING_LOCK:
+        if _TRACER is not None:
+            return _TRACER
+        if _TRACING_SHUT_DOWN:
+            return None
+        endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+        if not endpoint:
+            return None
+
+        try:
+            from opentelemetry import context as otel_context
+            from opentelemetry import trace as otel_trace
+            from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+            from opentelemetry.sdk.resources import Resource
+            from opentelemetry.sdk.trace import TracerProvider
+            from opentelemetry.sdk.trace.export import BatchSpanProcessor
+            from opentelemetry.sdk.trace.sampling import ALWAYS_ON
+        except ImportError:
+            return None
+
+        provider = TracerProvider(
+            resource=Resource.create(
+                {
+                    "service.name": os.getenv("OTEL_SERVICE_NAME", "frontend"),
+                    "expertkit.component": "frontend",
+                }
+            ),
+            sampler=ALWAYS_ON,
+        )
+        provider.add_span_processor(
+            BatchSpanProcessor(
+                OTLPSpanExporter(endpoint=endpoint.rstrip("/"), insecure=True),
+                schedule_delay_millis=100,
+                max_queue_size=16384,
+                max_export_batch_size=512,
+            )
+        )
+        _TRACER_PROVIDER = provider
+        _TRACER = _OpenTelemetryTracer(
+            provider.get_tracer("expertkit-transport"),
+            otel_context,
+            otel_trace,
+        )
+        return _TRACER
+
+
+def get_frontend_tracer() -> Tracer | None:
+    """Return the optional Frontend tracer, initializing it lazily."""
+
+    tracer = _TRACER
+    return tracer if tracer is not None else initialize_frontend_tracing()
+
+
+def trace_span(
+    tracer: Tracer | None,
+    name: str,
+    *,
+    context: TraceContext | None = None,
+    attributes: Mapping[str, TraceAttribute] | None = None,
+) -> AbstractContextManager[TraceSpan | None]:
+    """Start a span when tracing is enabled, otherwise return a no-op context."""
+
+    if tracer is None:
+        return nullcontext(None)
+    return tracer.start_as_current_span(name, context=context, attributes=attributes)
+
+
+def frontend_request_span(
+    *,
+    attributes: Mapping[str, TraceAttribute] | None = None,
+) -> AbstractContextManager[TraceSpan | None]:
+    """Create the root span for one caller-defined inference request."""
+
+    return trace_span(get_frontend_tracer(), "frontend.request", attributes=attributes)
+
+
+def current_trace_metadata() -> tuple[tuple[str, str], ...]:
+    """Inject only W3C trace context into gRPC metadata."""
+
+    try:
+        from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+    except ImportError:
+        return ()
+    carrier: dict[str, str] = {}
+    TraceContextTextMapPropagator().inject(carrier)
+    traceparent = carrier.get("traceparent")
+    return () if not traceparent else (("traceparent", traceparent),)
+
+
+def extract_trace_context(metadata: object) -> TraceContext | None:
+    """Extract W3C trace context from gRPC invocation metadata."""
+
+    try:
+        from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+    except ImportError:
+        return None
+
+    carrier: dict[str, str] = {}
+    for entry in metadata or ():
+        key = getattr(entry, "key", None)
+        value = getattr(entry, "value", None)
+        if key is None or value is None:
+            try:
+                key, value = entry
+            except (TypeError, ValueError):
+                continue
+        if isinstance(key, str) and isinstance(value, str):
+            carrier[key.lower()] = value
+    if "traceparent" not in carrier:
+        return None
+    return TraceContextTextMapPropagator().extract(carrier)
+
+
+def incoming_trace_context(tracer: Tracer | None, metadata: object) -> TraceContext | None:
+    """Capture an instrumented server span or extract the remote W3C parent."""
+
+    if tracer is None:
+        return None
+    if tracer.current_span_is_recording():
+        return tracer.capture_context()
+    return extract_trace_context(metadata)
+
+
+def flush_tracing() -> None:
+    """Force-export buffered Frontend spans without closing the provider."""
+
+    provider = _TRACER_PROVIDER
+    if provider is not None:
+        provider.force_flush()
+
+
+def shutdown_tracing() -> None:
+    """Flush and close Frontend tracing exactly once during process shutdown."""
+
+    global _TRACER_PROVIDER, _TRACER, _TRACING_SHUT_DOWN
+    with _TRACING_LOCK:
+        if _TRACING_SHUT_DOWN:
+            return
+        _TRACING_SHUT_DOWN = True
+        provider = _TRACER_PROVIDER
+        _TRACER_PROVIDER = None
+        _TRACER = None
+    if provider is not None:
+        provider.shutdown()
+
+
+atexit.register(shutdown_tracing)

--- a/ek-transport/src/expertkit_transport/transports/base.py
+++ b/ek-transport/src/expertkit_transport/transports/base.py
@@ -24,6 +24,12 @@ def _require_positive_unsigned(name: str, value: int, maximum: int) -> None:
 class WorkerTransport(ABC):
     """Submit Worker batches to one remote Worker."""
 
+    @property
+    def transport_name(self) -> str:
+        """Return the stable transport name used by observability attributes."""
+
+        return type(self).__name__
+
     @abstractmethod
     async def start(self) -> None:
         """Create Transport resources on the current event loop."""
@@ -141,6 +147,12 @@ class WorkerBatchBuffers(ABC):
 
 class ReceivedBatch(ABC):
     """Represent one admitted batch until computation and response finish."""
+
+    @property
+    def transport_name(self) -> str:
+        """Return the stable transport name used by observability attributes."""
+
+        return type(self).__name__
 
     @property
     @abstractmethod

--- a/ek-transport/src/expertkit_transport/transports/grpc/client.py
+++ b/ek-transport/src/expertkit_transport/transports/grpc/client.py
@@ -20,6 +20,7 @@ from expertkit_transport.errors import (
     TransportErrorCode,
     TransportProtocolError,
 )
+from expertkit_transport.tracing import current_trace_metadata, get_frontend_tracer, trace_span
 from expertkit_transport.transports.base import WorkerEndpointConfig, WorkerTransport
 from expertkit_transport.transports.grpc.client_buffers import (
     GrpcTransferBufferPool,
@@ -96,12 +97,12 @@ def _selected_hidden_states(batch: WorkerBatch) -> torch.Tensor:
         raise TransportProtocolError("Worker batch token indices are invalid") from error
 
 
-def _encode_with_staging(
+def _stage_request(
     batch: WorkerBatch,
     spec: WorkerEndpointConfig,
     buffers: GrpcTransferBuffers,
     stream: torch.cuda.Stream | None,
-) -> bytes:
+) -> None:
     validate_worker_batch(batch, spec)
     token_count = batch.token_count
     with torch.inference_mode():
@@ -130,6 +131,14 @@ def _encode_with_staging(
                 buffers.request_copy_recorded = True
             buffers.request_copy_event.synchronize()
 
+
+
+def _serialize_staged_request(
+    batch: WorkerBatch,
+    spec: WorkerEndpointConfig,
+    buffers: GrpcTransferBuffers,
+) -> bytes:
+    token_count = batch.token_count
     return _serialize_host_request(
         batch,
         spec,
@@ -185,6 +194,10 @@ def _validate_output(
 class GrpcWorkerTransport(WorkerTransport):
     """Send bounded asynchronous unary calls to one plaintext Worker endpoint."""
 
+    @property
+    def transport_name(self) -> str:
+        return "grpc"
+
     def __init__(
         self,
         endpoint: str,
@@ -218,6 +231,7 @@ class GrpcWorkerTransport(WorkerTransport):
             device=self._device,
             capacity=max_in_flight,
         )
+        self._tracer = get_frontend_tracer()
         self._semaphore = asyncio.Semaphore(max_in_flight)
         self._executor = ThreadPoolExecutor(
             max_workers=resolved_cpu_workers,
@@ -337,13 +351,21 @@ class GrpcWorkerTransport(WorkerTransport):
         _validate_output(output, batch, self._spec, self._device)
         stream = torch.cuda.current_stream(output.device) if output.device.type == "cuda" else None
         try:
-            request = await self._run_cpu(
-                _encode_with_staging,
-                batch,
-                self._spec,
-                buffers,
-                stream,
-            )
+            with trace_span(self._tracer, "frontend.tensor_slice"):
+                await self._run_cpu(
+                    _stage_request,
+                    batch,
+                    self._spec,
+                    buffers,
+                    stream,
+                )
+            with trace_span(self._tracer, "frontend.serialize"):
+                request = await self._run_cpu(
+                    _serialize_staged_request,
+                    batch,
+                    self._spec,
+                    buffers,
+                )
         except TransportProtocolError as error:
             raise TransportError(
                 TransportErrorCode.INVALID_REQUEST,
@@ -354,31 +376,40 @@ class GrpcWorkerTransport(WorkerTransport):
         remaining = monotonic_deadline - self._clock()
         if remaining <= 0:
             raise _deadline_error("deadline expired before the Worker gRPC call")
-        call = self._execute(
-            request,
-            timeout=None if math.isinf(remaining) else remaining,
-            wait_for_ready=False,
-        )
+        call: Any | None = None
         try:
-            response = await call
+            with trace_span(
+                self._tracer,
+                "frontend.send_worker",
+                attributes={"expertkit.transport": self.transport_name},
+            ):
+                call = self._execute(
+                    request,
+                    timeout=None if math.isinf(remaining) else remaining,
+                    wait_for_ready=False,
+                    metadata=current_trace_metadata(),
+                )
+                response = await call
         except asyncio.CancelledError:
-            call.cancel()
-            with suppress(BaseException):
-                await call
+            if call is not None:
+                call.cancel()
+                with suppress(BaseException):
+                    await call
             raise
         except grpc.aio.AioRpcError as error:
             raise _rpc_error(error) from error
 
         try:
-            await self._run_cpu(
-                _decode_into_output,
-                response,
-                batch.token_count,
-                self._spec,
-                buffers,
-                output,
-                stream,
-            )
+            with trace_span(self._tracer, "frontend.deserialize"):
+                await self._run_cpu(
+                    _decode_into_output,
+                    response,
+                    batch.token_count,
+                    self._spec,
+                    buffers,
+                    output,
+                    stream,
+                )
         except TransportProtocolError as error:
             raise TransportError(
                 TransportErrorCode.PROTOCOL,

--- a/ek-transport/src/expertkit_transport/transports/grpc/receiver.py
+++ b/ek-transport/src/expertkit_transport/transports/grpc/receiver.py
@@ -20,7 +20,12 @@ from expertkit_transport.errors import (
     TransportErrorCode,
     TransportProtocolError,
 )
-from expertkit_transport.tracing import TraceContext, Tracer, TraceSpan
+from expertkit_transport.tracing import (
+    TraceContext,
+    Tracer,
+    TraceSpan,
+    incoming_trace_context,
+)
 from expertkit_transport.transports.base import (
     BatchBufferConfig,
     ReceivedBatch,
@@ -93,6 +98,10 @@ class _GrpcReceivedBatch(ReceivedBatch):
         self.response: asyncio.Future[bytes] = asyncio.get_running_loop().create_future()
 
     @property
+    def transport_name(self) -> str:
+        return "grpc"
+
+    @property
     def trace_context(self) -> TraceContext | None:
         return self._trace_context
 
@@ -136,7 +145,7 @@ class _GrpcReceivedBatch(ReceivedBatch):
         if self._wait_span is not None:
             raise RuntimeError("gRPC waiting span is already active")
         self._wait_span = tracer.start_span(
-            "worker.request.wait",
+            "worker.queue_wait",
             context=self._trace_context,
             attributes=_batch_trace_attributes(self.batch),
         )
@@ -347,11 +356,12 @@ class GrpcWorkerBatchReceiver(WorkerBatchReceiver):
         if self._closing:
             self._record_rejection(TransportErrorCode.UNAVAILABLE.value)
             await context.abort(grpc.StatusCode.UNAVAILABLE, "Worker is shutting down")
-        trace_enabled = self._tracer is not None and self._tracer.current_span_is_recording()
-        trace_context = self._tracer.capture_context() if trace_enabled else None
+        trace_context = incoming_trace_context(self._tracer, context.invocation_metadata())
+        trace_enabled = trace_context is not None
         try:
             with self._trace_span(
-                "worker.request.decode",
+                "worker.request_decode",
+                context=trace_context,
                 attributes={"expertkit.request_bytes": len(payload)},
                 enabled=trace_enabled,
             ) as span:
@@ -377,7 +387,11 @@ class GrpcWorkerBatchReceiver(WorkerBatchReceiver):
         rejection = await self._admit(item)
         if rejection is not None:
             self._record_rejection(rejection.code.value)
-            with self._trace_span("worker.response.encode", enabled=trace_enabled):
+            with self._trace_span(
+                "worker.response_encode",
+                context=trace_context,
+                enabled=trace_enabled,
+            ):
                 return await self._run_cpu(encode_error_response, rejection, self._spec)
 
         try:
@@ -426,7 +440,7 @@ class GrpcWorkerBatchReceiver(WorkerBatchReceiver):
                 if partial_output.ndim != 2 or partial_output.shape[0] != item.token_count:
                     raise ValueError("partial output token count does not match the received batch")
                 with self._trace_span(
-                    "worker.response.encode",
+                    "worker.response_encode",
                     enabled=item.trace_context is not None,
                 ):
                     payload = await self._run_cpu(
@@ -454,7 +468,7 @@ class GrpcWorkerBatchReceiver(WorkerBatchReceiver):
                 status = _NATIVE_ERROR_STATUS.get(error.code)
                 if status is None:
                     with self._trace_span(
-                        "worker.response.encode",
+                        "worker.response_encode",
                         enabled=item.trace_context is not None,
                     ):
                         payload = await self._run_cpu(
@@ -494,12 +508,17 @@ class GrpcWorkerBatchReceiver(WorkerBatchReceiver):
         self,
         name: str,
         *,
+        context: TraceContext | None = None,
         attributes: dict[str, str | int] | None = None,
         enabled: bool = True,
     ) -> Any:
         if self._tracer is None or not enabled:
             return nullcontext(None)
-        return self._tracer.start_as_current_span(name, attributes=attributes)
+        return self._tracer.start_as_current_span(
+            name,
+            context=context,
+            attributes=attributes,
+        )
 
     def _record_rejection(self, reason: str) -> None:
         with suppress(Exception):

--- a/ek-transport/src/expertkit_transport/transports/shm/client.py
+++ b/ek-transport/src/expertkit_transport/transports/shm/client.py
@@ -20,6 +20,7 @@ from expertkit_transport.errors import (
     TransportErrorCode,
     TransportProtocolError,
 )
+from expertkit_transport.tracing import current_trace_metadata, get_frontend_tracer, trace_span
 from expertkit_transport.transports.base import WorkerEndpointConfig, WorkerTransport
 from expertkit_transport.transports.shm.client_buffers import (
     ShmTransferBufferPool,
@@ -178,6 +179,10 @@ def _validate_output(
 class ShmWorkerTransport(WorkerTransport):
     """Move Tensor bytes through fixed same-host slots and notify with gRPC."""
 
+    @property
+    def transport_name(self) -> str:
+        return "shm"
+
     def __init__(
         self,
         endpoint: str,
@@ -212,6 +217,7 @@ class ShmWorkerTransport(WorkerTransport):
             capacity=max_in_flight,
             device=self._device,
         )
+        self._tracer = get_frontend_tracer()
         self._semaphore = asyncio.Semaphore(max_in_flight)
         self._executor = ThreadPoolExecutor(
             max_workers=resolved_cpu_workers,
@@ -386,13 +392,14 @@ class ShmWorkerTransport(WorkerTransport):
         _validate_output(output, batch, self._spec, self._device)
         stream = torch.cuda.current_stream(output.device) if output.device.type == "cuda" else None
         try:
-            generation = await self._run_cpu(
-                _copy_request_to_slot,
-                batch,
-                self._spec,
-                buffers,
-                stream,
-            )
+            with trace_span(self._tracer, "frontend.tensor_slice"):
+                generation = await self._run_cpu(
+                    _copy_request_to_slot,
+                    batch,
+                    self._spec,
+                    buffers,
+                    stream,
+                )
         except TransportProtocolError as error:
             raise TransportError(
                 TransportErrorCode.INVALID_REQUEST,
@@ -408,49 +415,61 @@ class ShmWorkerTransport(WorkerTransport):
             if math.isinf(remaining)
             else max(1, min(_UINT64_MAX, math.ceil(remaining * 1_000_000)))
         )
-        request = encode_execute_request(
-            ExecuteSlot(
-                session_id=self._buffers.session_id,
-                slot_index=slot.index,
-                generation=generation,
-                layer_id=batch.layer_id,
-                topology_version=batch.topology_version,
-                token_count=batch.token_count,
-                timeout_micros=timeout_micros,
+        with trace_span(self._tracer, "frontend.serialize"):
+            request = encode_execute_request(
+                ExecuteSlot(
+                    session_id=self._buffers.session_id,
+                    slot_index=slot.index,
+                    generation=generation,
+                    layer_id=batch.layer_id,
+                    topology_version=batch.topology_version,
+                    token_count=batch.token_count,
+                    timeout_micros=timeout_micros,
+                )
             )
-        )
-        call = self._execute(
-            request,
-            timeout=None,
-            wait_for_ready=False,
-        )
+        call: Any | None = None
         try:
-            if math.isinf(remaining):
-                response = await asyncio.shield(call)
-            else:
-                try:
-                    async with asyncio.timeout(remaining):
-                        response = await asyncio.shield(call)
-                except TimeoutError as error:
-                    with suppress(BaseException):
-                        await call
-                    raise _deadline_error("the Worker shared-memory deadline expired") from error
+            with trace_span(
+                self._tracer,
+                "frontend.send_worker",
+                attributes={"expertkit.transport": self.transport_name},
+            ):
+                call = self._execute(
+                    request,
+                    timeout=None,
+                    wait_for_ready=False,
+                    metadata=current_trace_metadata(),
+                )
+                if math.isinf(remaining):
+                    response = await asyncio.shield(call)
+                else:
+                    try:
+                        async with asyncio.timeout(remaining):
+                            response = await asyncio.shield(call)
+                    except TimeoutError as error:
+                        with suppress(BaseException):
+                            await call
+                        raise _deadline_error(
+                            "the Worker shared-memory deadline expired"
+                        ) from error
         except asyncio.CancelledError:
-            with suppress(BaseException):
-                await call
+            if call is not None:
+                with suppress(BaseException):
+                    await call
             raise
         except grpc.aio.AioRpcError as error:
             raise _rpc_error(error) from error
 
         try:
-            decode_execute_response(response, generation, self._spec)
-            await self._run_cpu(
-                _copy_slot_to_output,
-                batch.token_count,
-                buffers,
-                output,
-                stream,
-            )
+            with trace_span(self._tracer, "frontend.deserialize"):
+                decode_execute_response(response, generation, self._spec)
+                await self._run_cpu(
+                    _copy_slot_to_output,
+                    batch.token_count,
+                    buffers,
+                    output,
+                    stream,
+                )
         except TransportProtocolError as error:
             raise TransportError(
                 TransportErrorCode.PROTOCOL,

--- a/ek-transport/src/expertkit_transport/transports/shm/receiver.py
+++ b/ek-transport/src/expertkit_transport/transports/shm/receiver.py
@@ -21,7 +21,12 @@ from expertkit_transport.errors import (
     TransportErrorCode,
     TransportProtocolError,
 )
-from expertkit_transport.tracing import TraceContext, Tracer, TraceSpan
+from expertkit_transport.tracing import (
+    TraceContext,
+    Tracer,
+    TraceSpan,
+    incoming_trace_context,
+)
 from expertkit_transport.transports.base import (
     BatchBufferConfig,
     ReceivedBatch,
@@ -113,6 +118,10 @@ class _ShmReceivedBatch(ReceivedBatch):
         self.response: asyncio.Future[bytes] = asyncio.get_running_loop().create_future()
 
     @property
+    def transport_name(self) -> str:
+        return "shm"
+
+    @property
     def trace_context(self) -> TraceContext | None:
         return self._trace_context
 
@@ -156,7 +165,7 @@ class _ShmReceivedBatch(ReceivedBatch):
         if self._wait_span is not None:
             raise RuntimeError("SHM waiting span is already active")
         self._wait_span = tracer.start_span(
-            "worker.request.wait",
+            "worker.queue_wait",
             context=self._trace_context,
             attributes=_batch_trace_attributes(self.batch),
         )
@@ -442,11 +451,12 @@ class ShmWorkerBatchReceiver(WorkerBatchReceiver):
         if self._closing:
             self._record_rejection(TransportErrorCode.UNAVAILABLE.value)
             await context.abort(grpc.StatusCode.UNAVAILABLE, "Worker is shutting down")
-        trace_enabled = self._tracer is not None and self._tracer.current_span_is_recording()
-        trace_context = self._tracer.capture_context() if trace_enabled else None
+        trace_context = incoming_trace_context(self._tracer, context.invocation_metadata())
+        trace_enabled = trace_context is not None
         try:
             with self._trace_span(
-                "worker.request.decode",
+                "worker.request_decode",
+                context=trace_context,
                 attributes={"expertkit.request_bytes": len(payload)},
                 enabled=trace_enabled,
             ) as span:
@@ -571,7 +581,7 @@ class ShmWorkerBatchReceiver(WorkerBatchReceiver):
                 if partial_output.data_ptr() != item.output_destination.data_ptr():
                     raise ValueError("SHM response did not use its claimed output destination")
                 with self._trace_span(
-                    "worker.response.encode",
+                    "worker.response_encode",
                     enabled=item.trace_context is not None,
                 ):
                     payload = encode_execute_success(item.generation)
@@ -595,7 +605,7 @@ class ShmWorkerBatchReceiver(WorkerBatchReceiver):
                 status = _NATIVE_ERROR_STATUS.get(error.code)
                 if status is None:
                     with self._trace_span(
-                        "worker.response.encode",
+                        "worker.response_encode",
                         enabled=item.trace_context is not None,
                     ):
                         payload = encode_execute_error(error, self._spec)
@@ -636,12 +646,17 @@ class ShmWorkerBatchReceiver(WorkerBatchReceiver):
         self,
         name: str,
         *,
+        context: TraceContext | None = None,
         attributes: dict[str, str | int] | None = None,
         enabled: bool = True,
     ) -> Any:
         if self._tracer is None or not enabled:
             return nullcontext(None)
-        return self._tracer.start_as_current_span(name, attributes=attributes)
+        return self._tracer.start_as_current_span(
+            name,
+            context=context,
+            attributes=attributes,
+        )
 
     def _record_rejection(self, reason: str) -> None:
         with suppress(Exception):

--- a/ek-transport/tests/unit/routing/test_dispatch.py
+++ b/ek-transport/tests/unit/routing/test_dispatch.py
@@ -1,6 +1,8 @@
 """Tests for bounded concurrent dispatch and FP32 aggregation."""
 
 import asyncio
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
 
 import pytest
 import torch
@@ -16,6 +18,7 @@ from expertkit_transport.routing import (
     dispatch_once,
     group_worker_batches,
 )
+from expertkit_transport.tracing import TraceAttribute, TraceContext, TraceSpan
 from expertkit_transport.transports.base import WorkerTransport
 
 
@@ -53,6 +56,59 @@ class FakeTransport(WorkerTransport):
 
     async def close(self) -> None:
         return None
+
+
+class RecordingSpan:
+    def __init__(
+        self,
+        name: str,
+        attributes: Mapping[str, TraceAttribute] | None,
+    ) -> None:
+        self.name = name
+        self.attributes = dict(attributes or {})
+
+    def is_recording(self) -> bool:
+        return True
+
+    def set_attribute(self, key: str, value: TraceAttribute) -> None:
+        self.attributes[key] = value
+
+    def end(self) -> None:
+        pass
+
+
+class RecordingTracer:
+    def __init__(self) -> None:
+        self.spans: list[RecordingSpan] = []
+
+    def current_span_is_recording(self) -> bool:
+        return True
+
+    def capture_context(self) -> TraceContext:
+        return object()
+
+    def start_span(
+        self,
+        name: str,
+        *,
+        context: TraceContext | None = None,
+        attributes: Mapping[str, TraceAttribute] | None = None,
+    ) -> TraceSpan:
+        del context
+        span = RecordingSpan(name, attributes)
+        self.spans.append(span)
+        return span
+
+    @contextmanager
+    def start_as_current_span(
+        self,
+        name: str,
+        *,
+        context: TraceContext | None = None,
+        attributes: Mapping[str, TraceAttribute] | None = None,
+    ) -> Iterator[TraceSpan]:
+        span = self.start_span(name, context=context, attributes=attributes)
+        yield span
 
 
 def target(name: str, transport: WorkerTransport) -> WorkerConnection:
@@ -104,9 +160,16 @@ def test_dispatches_workers_concurrently_and_aggregates_in_fp32() -> None:
         plans = group_worker_batches(routed_batch(), topology, RoundRobinSelector())
         pools = pools_for((worker_a, worker_b))
         accumulator = torch.zeros((3, 4), dtype=torch.float32)
+        tracer = RecordingTracer()
 
         dispatch = asyncio.create_task(
-            dispatch_once(plans, pools, accumulator, monotonic_deadline=float("inf"))
+            dispatch_once(
+                plans,
+                pools,
+                accumulator,
+                monotonic_deadline=float("inf"),
+                tracer=tracer,
+            )
         )
         await started_a.wait()
         await started_b.wait()
@@ -120,6 +183,14 @@ def test_dispatches_workers_concurrently_and_aggregates_in_fp32() -> None:
                 dtype=torch.float32,
             ),
         )
+        worker_spans = [span for span in tracer.spans if span.name == "frontend.worker_batch"]
+        assert len(worker_spans) == len(plans) == 2
+        assert {span.attributes["expertkit.worker_id"] for span in worker_spans} == {
+            "worker-a",
+            "worker-b",
+        }
+        assert all(span.attributes["expertkit.attempt"] == 1 for span in worker_spans)
+        assert sum(span.name == "frontend.merge" for span in tracer.spans) == len(plans)
         for pool in pools.values():
             await pool.close()
 

--- a/ek-transport/tests/unit/test_tracing.py
+++ b/ek-transport/tests/unit/test_tracing.py
@@ -1,0 +1,42 @@
+"""Tests for Frontend tracing exporter lifecycle."""
+
+from expertkit_transport import tracing
+
+
+class RecordingProvider:
+    def __init__(self) -> None:
+        self.flushes = 0
+        self.shutdowns = 0
+
+    def force_flush(self) -> None:
+        self.flushes += 1
+
+    def shutdown(self) -> None:
+        self.shutdowns += 1
+
+
+def test_flush_keeps_provider_available(monkeypatch) -> None:
+    provider = RecordingProvider()
+    monkeypatch.setattr(tracing, "_TRACER_PROVIDER", provider)
+
+    tracing.flush_tracing()
+    tracing.flush_tracing()
+
+    assert provider.flushes == 2
+    assert provider.shutdowns == 0
+    assert tracing._TRACER_PROVIDER is provider
+
+
+def test_shutdown_closes_provider_exactly_once(monkeypatch) -> None:
+    provider = RecordingProvider()
+    monkeypatch.setattr(tracing, "_TRACER_PROVIDER", provider)
+    monkeypatch.setattr(tracing, "_TRACER", object())
+    monkeypatch.setattr(tracing, "_TRACING_SHUT_DOWN", False)
+
+    tracing.shutdown_tracing()
+    tracing.shutdown_tracing()
+
+    assert provider.shutdowns == 1
+    assert tracing._TRACER_PROVIDER is None
+    assert tracing._TRACER is None
+    assert tracing._TRACING_SHUT_DOWN is True

--- a/ek-transport/tests/unit/transports/grpc/test_client.py
+++ b/ek-transport/tests/unit/transports/grpc/test_client.py
@@ -3,12 +3,13 @@
 import asyncio
 import time
 from collections.abc import Awaitable, Callable
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
 
 import grpc
 import pytest
 import torch
 
+import expertkit_transport.transports.grpc.client as grpc_client_module
 from expertkit_transport.batches import WorkerBatch
 from expertkit_transport.errors import TransportError, TransportErrorCode
 from expertkit_transport.transports import WorkerEndpointConfig
@@ -112,6 +113,55 @@ def test_client_compacts_request_and_fills_preallocated_output() -> None:
             await client.close()
 
     run(scenario())
+
+
+def test_client_records_real_stages_and_propagates_traceparent(monkeypatch) -> None:
+    stages: list[str] = []
+    span_attributes: dict[str, dict[str, object]] = {}
+    metadata: dict[str, str] = {}
+
+    @contextmanager
+    def record_span(_tracer: object, name: str, **kwargs: object):
+        stages.append(name)
+        span_attributes[name] = dict(kwargs.get("attributes") or {})  # type: ignore[arg-type]
+        yield None
+
+    monkeypatch.setattr(grpc_client_module, "get_frontend_tracer", object)
+    monkeypatch.setattr(grpc_client_module, "trace_span", record_span)
+    monkeypatch.setattr(
+        grpc_client_module,
+        "current_trace_metadata",
+        lambda: (("traceparent", "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01"),),
+    )
+
+    async def scenario() -> None:
+        async def execute(payload: bytes, context: grpc.aio.ServicerContext) -> bytes:
+            metadata.update(dict(context.invocation_metadata()))
+            source = decode_request(payload, batch_spec())
+            return encode_success_response(source.hidden_states, batch_spec())
+
+        async with raw_server(execute) as endpoint:
+            client = GrpcWorkerTransport(endpoint, batch_spec(), max_in_flight=1, device="cpu")
+            await client.start()
+            try:
+                await client.execute(
+                    worker_batch(),
+                    prepare_output(client),
+                    monotonic_deadline=float("inf"),
+                )
+            finally:
+                await client.close()
+
+    run(scenario())
+
+    assert stages == [
+        "frontend.tensor_slice",
+        "frontend.serialize",
+        "frontend.send_worker",
+        "frontend.deserialize",
+    ]
+    assert span_attributes["frontend.send_worker"]["expertkit.transport"] == "grpc"
+    assert metadata["traceparent"].startswith("00-0123456789abcdef")
 
 
 def test_client_maps_structured_computation_error() -> None:

--- a/ek-transport/tests/unit/transports/grpc/test_receiver.py
+++ b/ek-transport/tests/unit/transports/grpc/test_receiver.py
@@ -448,7 +448,7 @@ def test_application_pending_limit_returns_busy_and_cancellation_releases_input(
             await server._wait_pending_count(0)
         assert server.pending_retained_bytes == 0
         assert server.admitted_count(2, 0) == 0
-        waiting = [span for span in tracer.spans if span.name == "worker.request.wait"]
+        waiting = [span for span in tracer.spans if span.name == "worker.queue_wait"]
         assert len(waiting) == 1
         assert waiting[0].ended is True
         assert waiting[0].attributes["expertkit.outcome"] == "cancelled"
@@ -511,7 +511,7 @@ def test_receiver_close_clears_pending_retained_bytes() -> None:
         await server.close()
         assert server.pending_count == 0
         assert server.pending_retained_bytes == 0
-        waiting = [span for span in tracer.spans if span.name == "worker.request.wait"]
+        waiting = [span for span in tracer.spans if span.name == "worker.queue_wait"]
         assert len(waiting) == 1
         assert waiting[0].ended is True
         assert waiting[0].attributes["expertkit.outcome"] in {"cancelled", "closed"}

--- a/ek-transport/tests/unit/transports/shm/test_client_receiver.py
+++ b/ek-transport/tests/unit/transports/shm/test_client_receiver.py
@@ -2,12 +2,14 @@
 
 import asyncio
 import time
+from contextlib import contextmanager
 from dataclasses import replace
 
 import grpc
 import pytest
 import torch
 
+import expertkit_transport.transports.shm.client as shm_client_module
 from expertkit_transport.batches import WorkerBatch
 from expertkit_transport.errors import TransportError, TransportErrorCode
 from expertkit_transport.transports import WorkerEndpointConfig
@@ -99,6 +101,66 @@ def test_shared_memory_path_compacts_and_returns_without_tensor_payloads() -> No
             await server.close()
 
     asyncio.run(scenario())
+
+
+def test_shared_memory_records_stages_and_propagates_traceparent(monkeypatch) -> None:
+    stages: list[str] = []
+    span_attributes: dict[str, dict[str, object]] = {}
+    metadata: dict[str, str] = {}
+
+    @contextmanager
+    def record_span(_tracer: object, name: str, **kwargs: object):
+        stages.append(name)
+        span_attributes[name] = dict(kwargs.get("attributes") or {})  # type: ignore[arg-type]
+        yield None
+
+    monkeypatch.setattr(shm_client_module, "get_frontend_tracer", object)
+    monkeypatch.setattr(shm_client_module, "trace_span", record_span)
+    monkeypatch.setattr(
+        shm_client_module,
+        "current_trace_metadata",
+        lambda: (("traceparent", "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01"),),
+    )
+    original_execute = ShmWorkerBatchReceiver._execute_shared_memory
+
+    async def capture(
+        receiver: ShmWorkerBatchReceiver,
+        payload: bytes,
+        context: grpc.aio.ServicerContext,
+    ) -> bytes:
+        metadata.update(dict(context.invocation_metadata()))
+        return await original_execute(receiver, payload, context)
+
+    monkeypatch.setattr(ShmWorkerBatchReceiver, "_execute_shared_memory", capture)
+
+    async def scenario() -> None:
+        server, client = await start_pair()
+        output = prepare(client)
+        try:
+            submission = asyncio.create_task(
+                client.execute(batch(), output, monotonic_deadline=time.monotonic() + 5)
+            )
+            received = await server.receive()
+            destination = received.output_destination
+            assert destination is not None
+            destination.copy_(received.batch.hidden_states)
+            received.release_input()
+            await received.complete(destination)
+            await submission
+        finally:
+            await client.close()
+            await server.close()
+
+    asyncio.run(scenario())
+
+    assert stages == [
+        "frontend.tensor_slice",
+        "frontend.serialize",
+        "frontend.send_worker",
+        "frontend.deserialize",
+    ]
+    assert span_attributes["frontend.send_worker"]["expertkit.transport"] == "shm"
+    assert metadata["traceparent"].startswith("00-0123456789abcdef")
 
 
 def test_worker_revalidates_routing_values_from_shared_memory() -> None:

--- a/ek-worker/src/expertkit_worker/control/__init__.py
+++ b/ek-worker/src/expertkit_worker/control/__init__.py
@@ -5,7 +5,9 @@ from expertkit_worker.control.lifecycle import (
     HeartbeatSender,
     RegistrationResult,
     WorkerRegistration,
+    WorkerRuntimeIdentity,
     new_start_id,
+    new_worker_runtime_identity,
 )
 from expertkit_worker.control.parts import (
     DrainAuthorization,
@@ -33,5 +35,7 @@ __all__ = [
     "WeightControlDrainError",
     "WeightControlSession",
     "WorkerRegistration",
+    "WorkerRuntimeIdentity",
     "new_start_id",
+    "new_worker_runtime_identity",
 ]

--- a/ek-worker/src/expertkit_worker/control/factory.py
+++ b/ek-worker/src/expertkit_worker/control/factory.py
@@ -10,7 +10,7 @@ from expertkit_worker.control.lifecycle import (
     ControllerConnection,
     HeartbeatSender,
     WorkerRegistration,
-    new_start_id,
+    WorkerRuntimeIdentity,
 )
 from expertkit_worker.control.state_reporter import ExpertStateReporter
 from expertkit_worker.control.supervisor import ControllerSupervisor
@@ -21,6 +21,7 @@ from expertkit_worker.weights.manager import WeightManager
 def create_controller_supervisor(
     config: WorkerConfig,
     *,
+    identity: WorkerRuntimeIdentity,
     instance_id: int,
     activation_dtype: torch.dtype,
     receiver: WorkerBatchReceiver,
@@ -31,16 +32,15 @@ def create_controller_supervisor(
 ) -> ControllerSupervisor:
     """Create the complete Controller-facing control path for one Worker."""
 
-    start_id = new_start_id()
     connection = ControllerConnection(config.controller.endpoint)
     heartbeat = HeartbeatSender(
-        worker_id=config.worker.id,
-        start_id=start_id,
+        worker_id=identity.worker_id,
+        start_id=identity.start_id,
         interval_secs=config.controller.heartbeat_interval_secs,
     )
     weights = WeightControlSession(
-        worker_id=config.worker.id,
-        start_id=start_id,
+        worker_id=identity.worker_id,
+        start_id=identity.start_id,
         max_experts=manager.max_experts,
         shutdown_grace_secs=config.worker.shutdown_grace_secs,
         manager=manager,
@@ -48,8 +48,8 @@ def create_controller_supervisor(
         receiver=receiver,
     )
     registration = WorkerRegistration(
-        worker_id=config.worker.id,
-        start_id=start_id,
+        worker_id=identity.worker_id,
+        start_id=identity.start_id,
         instance_id=instance_id,
         computation_endpoint=computation_endpoint,
         peer_weight_endpoint=str(config.weight_manager.peer.advertise),

--- a/ek-worker/src/expertkit_worker/control/lifecycle.py
+++ b/ek-worker/src/expertkit_worker/control/lifecycle.py
@@ -39,6 +39,24 @@ def new_start_id() -> str:
     return str(uuid4())
 
 
+@dataclass(frozen=True, slots=True)
+class WorkerRuntimeIdentity:
+    """Identify one logical Worker and one concrete process lifetime."""
+
+    worker_id: str
+    start_id: str
+
+    def __post_init__(self) -> None:
+        _require_text("worker_id", self.worker_id)
+        _require_text("start_id", self.start_id)
+
+
+def new_worker_runtime_identity(worker_id: str) -> WorkerRuntimeIdentity:
+    """Create the single identity shared by all components in one Worker process."""
+
+    return WorkerRuntimeIdentity(worker_id=worker_id, start_id=new_start_id())
+
+
 def _require_text(name: str, value: str) -> None:
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{name} must not be empty")

--- a/ek-worker/src/expertkit_worker/execution/executor.py
+++ b/ek-worker/src/expertkit_worker/execution/executor.py
@@ -28,6 +28,7 @@ from expertkit_worker.backends import (
     InvalidBackendInput,
     UnsupportedBackendBatch,
 )
+from expertkit_worker.control.lifecycle import WorkerRuntimeIdentity
 from expertkit_worker.execution.slot import ExecutionResult, ExecutionSlot
 from expertkit_worker.observability.api import NoopWorkerMetrics, WorkerMetrics
 
@@ -70,6 +71,7 @@ class WorkerExecutor:
         backend: ComputeBackend,
         *,
         instance_id: int,
+        identity: WorkerRuntimeIdentity,
         buffer_config: BatchBufferConfig,
         slot_count: int,
         clock: Callable[[], float] = time.monotonic,
@@ -80,6 +82,8 @@ class WorkerExecutor:
             raise ValueError("instance_id must be a positive integer")
         if isinstance(slot_count, bool) or not isinstance(slot_count, int) or slot_count <= 0:
             raise ValueError("slot_count must be a positive integer")
+        if not isinstance(identity, WorkerRuntimeIdentity):
+            raise TypeError("identity must be a WorkerRuntimeIdentity")
         backend.capabilities.validate_runtime(
             max_batch_tokens=buffer_config.max_batch_tokens,
             active_batches=slot_count,
@@ -88,6 +92,7 @@ class WorkerExecutor:
         self._receiver = receiver
         self._backend = backend
         self._instance_id = instance_id
+        self._identity = identity
         self._clock = clock
         self._metrics = metrics or NoopWorkerMetrics()
         self._tracer = tracer
@@ -217,11 +222,17 @@ class WorkerExecutor:
             "expertkit.topology_version": batch.topology_version,
             "expertkit.token_count": batch.token_count,
             "expertkit.assignment_count": batch.token_count * batch.top_k,
+            "expertkit.expert_ids": ",".join(
+                str(expert_id) for expert_id in batch.distinct_expert_ids
+            ),
+            "expertkit.worker_id": self._identity.worker_id,
+            "expertkit.worker_start_id": self._identity.start_id,
+            "expertkit.transport": received.transport_name,
             "expertkit.backend": type(self._backend).__name__,
             "expertkit.device": str(slot.device),
         }
         span_context = self._tracer.start_as_current_span(
-            "worker.batch.execute",
+            "worker.forward",
             context=received.trace_context,
             attributes=attributes,
         )

--- a/ek-worker/src/expertkit_worker/execution/slot.py
+++ b/ek-worker/src/expertkit_worker/execution/slot.py
@@ -271,7 +271,7 @@ class ExecutionSlot:
         clock: Callable[[], float],
         tracer: Tracer | None,
     ) -> ExecutionResult:
-        with _trace_span(tracer, "worker.input.prepare"):
+        with _trace_span(tracer, "worker.deserialize"):
             batch = self._copy_and_build_batch(
                 received,
                 source,
@@ -282,13 +282,13 @@ class ExecutionSlot:
         rejection = _request_end_error(received, clock)
         if rejection is not None:
             return self._set_result(None, rejection, None)
-        with _trace_span(tracer, "worker.backend.submit"):
+        with _trace_span(tracer, "worker.compute_submit"):
             completion = self._submit(backend, batch, output)
         try:
-            with _trace_span(tracer, "worker.backend.wait"):
+            with _trace_span(tracer, "worker.compute_wait"):
                 self._wait_completion(completion)
             rejection = _request_end_error(received, clock)
-            with _trace_span(tracer, "worker.output.prepare"):
+            with _trace_span(tracer, "worker.serialize"):
                 response_output = (
                     None
                     if rejection is not None
@@ -327,7 +327,7 @@ class ExecutionSlot:
             with torch.cuda.device(self._spec.device), torch.cuda.stream(stream):
                 if timing_events is not None:
                     timing_events[0].record(stream)
-                with _trace_span(tracer, "worker.input.prepare"):
+                with _trace_span(tracer, "worker.deserialize"):
                     batch = self._copy_and_build_batch(
                         received,
                         source,
@@ -339,14 +339,14 @@ class ExecutionSlot:
                     timing_events[1].record(stream)
                 rejection = _request_end_error(received, clock)
                 if rejection is None:
-                    with _trace_span(tracer, "worker.backend.submit"):
+                    with _trace_span(tracer, "worker.compute_submit"):
                         completion = self._submit(backend, batch, output)
                 if timing_events is not None:
                     timing_events[2].record(stream)
                 if completion is not None:
                     rejection = _request_end_error(received, clock)
                     if rejection is None:
-                        with _trace_span(tracer, "worker.output.prepare"):
+                        with _trace_span(tracer, "worker.serialize"):
                             response_output = self._transport_buffers.copy_output(
                                 output,
                                 received.output_destination,
@@ -356,7 +356,7 @@ class ExecutionSlot:
                 event.record(stream)
 
             try:
-                with _trace_span(tracer, "worker.device.wait"):
+                with _trace_span(tracer, "worker.compute_wait"):
                     event.synchronize()
             except torch.OutOfMemoryError as error:
                 raise BackendFatalError(BackendFatalReason.DEVICE_OOM, str(error)) from error
@@ -374,7 +374,7 @@ class ExecutionSlot:
                     input_ms + backend_ms + output_ms,
                 )
             if completion is not None:
-                with _trace_span(tracer, "worker.backend.wait"):
+                with _trace_span(tracer, "worker.compute_wait"):
                     self._wait_completion(completion)
             final_rejection = _request_end_error(received, clock)
             if final_rejection is not None:

--- a/ek-worker/src/expertkit_worker/factory.py
+++ b/ek-worker/src/expertkit_worker/factory.py
@@ -12,6 +12,7 @@ from expertkit_transport.controller import (
     ResolvedDefaultInstance,
     resolve_default_instance,
 )
+from expertkit_transport.tracing import trace_span
 from expertkit_transport.transports.base import (
     BatchBufferConfig,
     WorkerBatchReceiver,
@@ -35,6 +36,7 @@ from expertkit_worker.config import (
 )
 from expertkit_worker.control import (
     ExpertStateReporter,
+    new_worker_runtime_identity,
 )
 from expertkit_worker.control.factory import create_controller_supervisor
 from expertkit_worker.execution import WorkerExecutor
@@ -104,6 +106,7 @@ async def build_worker_application(
         timeout_seconds=config.controller.heartbeat_timeout_secs,
     )
     instance_id = resolved_instance.instance_id
+    identity = new_worker_runtime_identity(config.worker.id)
     activation_dtype = torch_dtype(config.model.activation_dtype)
     weight_dtype = torch_dtype(config.model.weight_dtype)
     device = torch.device(config.worker.device)
@@ -112,7 +115,7 @@ async def build_worker_application(
 
     observability = create_observability(
         config.observability,
-        worker_id=config.worker.id,
+        identity=identity,
     )
     metrics = observability.metrics
     receiver: WorkerBatchReceiver | None = None
@@ -170,7 +173,17 @@ async def build_worker_application(
             current = manager_holder[0]
             if current is None:
                 raise RuntimeError("Weight Manager is not installed in the selected Backend")
-            return current.acquire_many(layer_id, expert_ids)
+            with trace_span(
+                observability.tracer,
+                "worker.load_expert",
+                attributes={
+                    "expertkit.layer_id": layer_id,
+                    "expertkit.expert_ids": ",".join(str(expert_id) for expert_id in expert_ids),
+                    "expertkit.worker_id": identity.worker_id,
+                    "expertkit.worker_start_id": identity.start_id,
+                },
+            ):
+                return current.acquire_many(layer_id, expert_ids)
 
         backend = create_compute_backend(
             config,
@@ -189,6 +202,7 @@ async def build_worker_application(
             receiver,
             backend,
             instance_id=instance_id,
+            identity=identity,
             buffer_config=buffer_config,
             slot_count=config.worker.max_active_batches_per_device,
             metrics=metrics,
@@ -240,6 +254,7 @@ async def build_worker_application(
 
         control = create_controller_supervisor(
             config,
+            identity=identity,
             instance_id=instance_id,
             activation_dtype=activation_dtype,
             receiver=receiver,

--- a/ek-worker/src/expertkit_worker/observability/runtime.py
+++ b/ek-worker/src/expertkit_worker/observability/runtime.py
@@ -10,6 +10,7 @@ from typing import Any, Protocol
 from expertkit_transport.tracing import TraceAttribute, TraceContext, Tracer, TraceSpan
 
 from expertkit_worker.config.models import ObservabilityConfig
+from expertkit_worker.control.lifecycle import WorkerRuntimeIdentity
 from expertkit_worker.observability.api import NoopWorkerMetrics, WorkerMetrics
 
 
@@ -139,10 +140,26 @@ class _PrometheusMetrics:
 class _OpenTelemetryTracer:
     """Adapt one configured OpenTelemetry tracer to the shared tracing boundary."""
 
-    def __init__(self, tracer: Any, context_api: Any, trace_api: Any) -> None:
+    def __init__(
+        self,
+        tracer: Any,
+        context_api: Any,
+        trace_api: Any,
+        *,
+        default_attributes: Mapping[str, TraceAttribute],
+    ) -> None:
         self._tracer = tracer
         self._context_api = context_api
         self._trace_api = trace_api
+        self._default_attributes = dict(default_attributes)
+
+    def _attributes(
+        self,
+        attributes: Mapping[str, TraceAttribute] | None,
+    ) -> dict[str, TraceAttribute]:
+        merged = dict(self._default_attributes)
+        merged.update(attributes or {})
+        return merged
 
     def current_span_is_recording(self) -> bool:
         return bool(self._trace_api.get_current_span().is_recording())
@@ -160,7 +177,7 @@ class _OpenTelemetryTracer:
         return self._tracer.start_span(
             name,
             context=context,
-            attributes=None if attributes is None else dict(attributes),
+            attributes=self._attributes(attributes),
         )
 
     def start_as_current_span(
@@ -173,12 +190,12 @@ class _OpenTelemetryTracer:
         return self._tracer.start_as_current_span(
             name,
             context=context,
-            attributes=None if attributes is None else dict(attributes),
+            attributes=self._attributes(attributes),
         )
 
 
 class _OptionalObservability:
-    def __init__(self, config: ObservabilityConfig, *, worker_id: str) -> None:
+    def __init__(self, config: ObservabilityConfig, *, identity: WorkerRuntimeIdentity) -> None:
         self._listen = config.prometheus.listen if config.prometheus.enabled else None
         self._metrics_server: Any = None
         self._metrics_thread: Any = None
@@ -199,6 +216,7 @@ class _OptionalObservability:
         self._interceptors: tuple[Any, ...] = ()
         if config.tracing.enabled:
             from opentelemetry import context as otel_context
+            from opentelemetry import propagate
             from opentelemetry import trace as otel_trace
             from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
             from opentelemetry.instrumentation.grpc import aio_server_interceptor
@@ -206,13 +224,17 @@ class _OptionalObservability:
             from opentelemetry.sdk.trace import TracerProvider
             from opentelemetry.sdk.trace.export import BatchSpanProcessor
             from opentelemetry.sdk.trace.sampling import ParentBased, TraceIdRatioBased
+            from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
             endpoint = str(config.tracing.endpoint).rstrip("/")
             provider = TracerProvider(
                 resource=Resource.create(
                     {
-                        "service.name": "expertkit-worker",
-                        "service.instance.id": worker_id,
+                        "service.name": identity.worker_id,
+                        "service.instance.id": identity.start_id,
+                        "expertkit.component": "worker",
+                        "expertkit.worker_id": identity.worker_id,
+                        "expertkit.worker_start_id": identity.start_id,
                     }
                 ),
                 sampler=ParentBased(TraceIdRatioBased(config.tracing.sample_ratio)),
@@ -231,7 +253,12 @@ class _OptionalObservability:
                 provider.get_tracer("expertkit-worker"),
                 otel_context,
                 otel_trace,
+                default_attributes={
+                    "expertkit.worker_id": identity.worker_id,
+                    "expertkit.worker_start_id": identity.start_id,
+                },
             )
+            propagate.set_global_textmap(TraceContextTextMapPropagator())
             self._interceptors = (aio_server_interceptor(tracer_provider=provider),)
 
     @property
@@ -284,7 +311,7 @@ class _OptionalObservability:
 def create_observability(
     config: ObservabilityConfig,
     *,
-    worker_id: str,
+    identity: WorkerRuntimeIdentity,
 ) -> WorkerObservability:
     """Build disabled state or import the optional exporter stack on demand.
 
@@ -295,7 +322,7 @@ def create_observability(
     if not config.prometheus.enabled and not config.tracing.enabled:
         return _NoopObservability()
     try:
-        return _OptionalObservability(config, worker_id=worker_id)
+        return _OptionalObservability(config, identity=identity)
     except ModuleNotFoundError as error:
         raise RuntimeError(
             "enabled Worker observability requires the locked observability extra"

--- a/ek-worker/tests/fixtures/cpu_worker_process.py
+++ b/ek-worker/tests/fixtures/cpu_worker_process.py
@@ -30,7 +30,7 @@ from expertkit_worker.control import (
     HeartbeatSender,
     WeightControlSession,
     WorkerRegistration,
-    new_start_id,
+    new_worker_runtime_identity,
 )
 from expertkit_worker.execution import WorkerExecutor
 from expertkit_worker.observability import configure_logging, create_observability
@@ -139,6 +139,7 @@ async def _run(args: argparse.Namespace) -> None:
     _install_weight(args.cache_root)
     args.active_marker.unlink(missing_ok=True)
     args.pending_marker.unlink(missing_ok=True)
+    identity = new_worker_runtime_identity(args.worker_id)
 
     adapter = TorchWeightAdapter(
         hidden_dim=_HIDDEN_DIM,
@@ -195,6 +196,7 @@ async def _run(args: argparse.Namespace) -> None:
         receiver,
         backend,
         instance_id=_INSTANCE_ID,
+        identity=identity,
         buffer_config=BatchBufferConfig(
             max_batch_tokens=_MAX_BATCH_TOKENS,
             hidden_dim=_HIDDEN_DIM,
@@ -258,16 +260,15 @@ async def _run(args: argparse.Namespace) -> None:
         loader=loader,
     )
 
-    start_id = new_start_id()
     connection = ControllerConnection(args.controller)
     heartbeat = HeartbeatSender(
-        worker_id=args.worker_id,
-        start_id=start_id,
+        worker_id=identity.worker_id,
+        start_id=identity.start_id,
         interval_secs=0.05,
     )
     weights = WeightControlSession(
-        worker_id=args.worker_id,
-        start_id=start_id,
+        worker_id=identity.worker_id,
+        start_id=identity.start_id,
         max_experts=1,
         shutdown_grace_secs=5.0,
         manager=manager,
@@ -275,8 +276,8 @@ async def _run(args: argparse.Namespace) -> None:
         receiver=receiver,
     )
     registration = WorkerRegistration(
-        worker_id=args.worker_id,
-        start_id=start_id,
+        worker_id=identity.worker_id,
+        start_id=identity.start_id,
         instance_id=_INSTANCE_ID,
         computation_endpoint=args.computation_listen,
         peer_weight_endpoint="http://127.0.0.1:1",
@@ -299,7 +300,7 @@ async def _run(args: argparse.Namespace) -> None:
         retry_max_secs=0.2,
         stable_stream_secs=0.2,
     )
-    observability = create_observability(ObservabilityConfig(), worker_id=args.worker_id)
+    observability = create_observability(ObservabilityConfig(), identity=identity)
     application = WorkerApplication(
         transfer=transfer,
         manager=manager,

--- a/ek-worker/tests/integration/execution/test_executor.py
+++ b/ek-worker/tests/integration/execution/test_executor.py
@@ -28,6 +28,7 @@ from expertkit_worker.backends import (
     CompletedSubmission,
     ComputeBackend,
 )
+from expertkit_worker.control import WorkerRuntimeIdentity
 from expertkit_worker.execution import WorkerExecutor
 from expertkit_worker.observability.api import WorkerMetrics
 
@@ -175,6 +176,7 @@ async def start_stack(
         server,
         backend,
         instance_id=7,
+        identity=WorkerRuntimeIdentity("worker-test", "worker-test-start"),
         buffer_config=buffer_config(),
         slot_count=active,
         metrics=metrics,

--- a/ek-worker/tests/integration/execution/test_routed_layer_grpc.py
+++ b/ek-worker/tests/integration/execution/test_routed_layer_grpc.py
@@ -23,6 +23,7 @@ from expertkit_transport.transports.grpc import (
 )
 
 from expertkit_worker.backends.torch import TorchBackend, TorchExpertWeights
+from expertkit_worker.control import WorkerRuntimeIdentity
 from expertkit_worker.execution import WorkerExecutor
 from expertkit_worker.weights import ReadyWeightTable
 
@@ -131,6 +132,7 @@ async def _start_worker(
         server,
         backend,
         instance_id=_INSTANCE_ID,
+        identity=WorkerRuntimeIdentity(worker_id, f"{worker_id}-start"),
         buffer_config=BatchBufferConfig(
             max_batch_tokens=_MAX_BATCH_TOKENS,
             hidden_dim=_HIDDEN_DIM,

--- a/ek-worker/tests/integration/execution/test_routed_layer_shm.py
+++ b/ek-worker/tests/integration/execution/test_routed_layer_shm.py
@@ -10,6 +10,7 @@ from expertkit_transport.transports.base import BatchBufferConfig
 from expertkit_transport.transports.shm import ShmWorkerBatchReceiver, ShmWorkerTransport
 
 from expertkit_worker.backends.torch import TorchBackend, TorchExpertWeights
+from expertkit_worker.control import WorkerRuntimeIdentity
 from expertkit_worker.execution import WorkerExecutor
 from expertkit_worker.weights import ReadyWeightTable
 
@@ -75,6 +76,7 @@ def test_worker_execution_uses_shared_input_and_output_destinations() -> None:
             server,
             backend,
             instance_id=7,
+            identity=WorkerRuntimeIdentity("worker-shm", "worker-shm-start"),
             buffer_config=BatchBufferConfig(4, _HIDDEN_DIM, 2, torch.float32, "cpu"),
             slot_count=1,
         )

--- a/ek-worker/tests/integration/observability/test_observability.py
+++ b/ek-worker/tests/integration/observability/test_observability.py
@@ -6,6 +6,7 @@ import asyncio
 import socket
 from typing import Any
 
+import expertkit_transport.transports.shm.client as shm_client_module
 import grpc
 import pytest
 import torch
@@ -18,6 +19,7 @@ from expertkit_transport.transports.grpc import (
     decode_response,
     encode_request,
 )
+from expertkit_transport.transports.shm import ShmWorkerBatchReceiver, ShmWorkerTransport
 
 from expertkit_worker.backends import (
     BackendBatch,
@@ -28,6 +30,7 @@ from expertkit_worker.backends import (
     ComputeBackend,
 )
 from expertkit_worker.config.models import ObservabilityConfig
+from expertkit_worker.control import WorkerRuntimeIdentity
 from expertkit_worker.execution import WorkerExecutor
 from expertkit_worker.observability import create_observability
 
@@ -43,6 +46,7 @@ from opentelemetry.proto.collector.trace.v1 import (
 _EXECUTE_METHOD = "/ek.worker.v2.ComputationService/Execute"
 _TRACE_ID = "0123456789abcdef0123456789abcdef"
 _REMOTE_PARENT_SPAN_ID = "0123456789abcdef"
+_IDENTITY = WorkerRuntimeIdentity("worker-0", "worker-0-start")
 
 
 def _unused_port() -> int:
@@ -113,6 +117,10 @@ class _TraceCollector(trace_service_pb2_grpc.TraceServiceServicer):
         return trace_service_pb2.ExportTraceServiceResponse()
 
 
+def _string_attributes(attributes: Any) -> dict[str, str]:
+    return {attribute.key: attribute.value.string_value for attribute in attributes}
+
+
 def test_prometheus_listener_exposes_low_cardinality_worker_metrics() -> None:
     async def scenario() -> None:
         port = _unused_port()
@@ -124,7 +132,7 @@ def test_prometheus_listener_exposes_low_cardinality_worker_metrics() -> None:
                 }
             }
         )
-        observability = create_observability(config, worker_id="worker-0")
+        observability = create_observability(config, identity=_IDENTITY)
         assert observability.tracer is None
         await observability.start()
         try:
@@ -177,7 +185,7 @@ def test_tracing_extracts_parent_context_and_exports_off_the_rpc_path() -> None:
                 }
             }
         )
-        observability = create_observability(config, worker_id="worker-0")
+        observability = create_observability(config, identity=_IDENTITY)
         server = GrpcWorkerBatchReceiver(
             "127.0.0.1:0",
             _spec(),
@@ -190,6 +198,7 @@ def test_tracing_extracts_parent_context_and_exports_off_the_rpc_path() -> None:
             server,
             _DoubleBackend(),
             instance_id=7,
+            identity=_IDENTITY,
             buffer_config=BatchBufferConfig(2, 2, 1, torch.float32, "cpu"),
             slot_count=1,
             tracer=observability.tracer,
@@ -232,35 +241,175 @@ def test_tracing_extracts_parent_context_and_exports_off_the_rpc_path() -> None:
             for scope in resource.scope_spans
             for span in scope.spans
         ]
+        resources = [
+            resource.resource
+            for request in collector.requests
+            for resource in request.resource_spans
+        ]
+        assert any(
+            _string_attributes(resource.attributes).get("service.name") == "worker-0"
+            and _string_attributes(resource.attributes).get("service.instance.id")
+            == "worker-0-start"
+            for resource in resources
+        )
         traced = [span for span in spans if span.trace_id == bytes.fromhex(_TRACE_ID)]
         assert traced, [
             (span.name, span.trace_id.hex(), span.parent_span_id.hex()) for span in spans
         ]
         by_name = {span.name: span for span in traced}
         expected = {
-            "worker.request.decode",
-            "worker.request.wait",
-            "worker.batch.execute",
-            "worker.input.prepare",
-            "worker.backend.submit",
-            "worker.backend.wait",
-            "worker.output.prepare",
-            "worker.response.encode",
+            "worker.request_decode",
+            "worker.queue_wait",
+            "worker.forward",
+            "worker.deserialize",
+            "worker.compute_submit",
+            "worker.compute_wait",
+            "worker.serialize",
+            "worker.response_encode",
         }
         assert expected <= by_name.keys()
 
         server_span = next(
             span for span in traced if span.parent_span_id == bytes.fromhex(_REMOTE_PARENT_SPAN_ID)
         )
-        for name in ("worker.request.decode", "worker.request.wait", "worker.batch.execute"):
+        for name in ("worker.request_decode", "worker.queue_wait", "worker.forward"):
             assert by_name[name].parent_span_id == server_span.span_id
         for name in (
-            "worker.input.prepare",
-            "worker.backend.submit",
-            "worker.backend.wait",
-            "worker.output.prepare",
-            "worker.response.encode",
+            "worker.deserialize",
+            "worker.compute_submit",
+            "worker.compute_wait",
+            "worker.serialize",
+            "worker.response_encode",
         ):
-            assert by_name[name].parent_span_id == by_name["worker.batch.execute"].span_id
+            assert by_name[name].parent_span_id == by_name["worker.forward"].span_id
+        for name in expected:
+            attributes = _string_attributes(by_name[name].attributes)
+            assert attributes["expertkit.worker_id"] == "worker-0"
+            assert attributes["expertkit.worker_start_id"] == "worker-0-start"
+        assert (
+            _string_attributes(by_name["worker.forward"].attributes)[
+                "expertkit.transport"
+            ]
+            == "grpc"
+        )
+
+    asyncio.run(scenario())
+
+
+def test_shm_tracing_preserves_remote_parent_through_worker_execution(monkeypatch) -> None:
+    traceparent = f"00-{_TRACE_ID}-{_REMOTE_PARENT_SPAN_ID}-01"
+    monkeypatch.setattr(
+        shm_client_module,
+        "current_trace_metadata",
+        lambda: (("traceparent", traceparent),),
+    )
+
+    async def scenario() -> None:
+        collector = _TraceCollector()
+        collector_server = grpc.aio.server()
+        trace_service_pb2_grpc.add_TraceServiceServicer_to_server(
+            collector,
+            collector_server,
+        )
+        collector_port = collector_server.add_insecure_port("127.0.0.1:0")
+        await collector_server.start()
+        config = ObservabilityConfig.model_validate(
+            {
+                "tracing": {
+                    "enabled": True,
+                    "endpoint": f"http://127.0.0.1:{collector_port}",
+                    "sample_ratio": 1,
+                }
+            }
+        )
+        observability = create_observability(config, identity=_IDENTITY)
+        receiver = ShmWorkerBatchReceiver(
+            "127.0.0.1:0",
+            _spec(),
+            max_active_batches=1,
+            max_pending_batches=1,
+            interceptors=observability.grpc_interceptors,
+            tracer=observability.tracer,
+        )
+        execution = WorkerExecutor(
+            receiver,
+            _DoubleBackend(),
+            instance_id=7,
+            identity=_IDENTITY,
+            buffer_config=BatchBufferConfig(2, 2, 1, torch.float32, "cpu"),
+            slot_count=1,
+            tracer=observability.tracer,
+        )
+        client: ShmWorkerTransport | None = None
+        await observability.start()
+        await execution.start()
+        try:
+            client = ShmWorkerTransport(
+                f"127.0.0.1:{receiver.bound_port}",
+                _spec(),
+                max_in_flight=2,
+                device="cpu",
+            )
+            await client.start()
+            output = torch.empty((1, 2), dtype=torch.float32)
+            await client.execute(
+                _batch(),
+                output,
+                monotonic_deadline=float("inf"),
+            )
+            torch.testing.assert_close(
+                output,
+                torch.tensor([[2.0, 4.0]], dtype=torch.float32),
+            )
+            async with asyncio.timeout(2):
+                await collector.received.wait()
+            collector.release.set()
+        finally:
+            collector.release.set()
+            if client is not None:
+                await client.close()
+            await execution.close()
+            await observability.close()
+            await collector_server.stop(None)
+
+        spans = [
+            span
+            for request in collector.requests
+            for resource in request.resource_spans
+            for scope in resource.scope_spans
+            for span in scope.spans
+            if span.trace_id == bytes.fromhex(_TRACE_ID)
+        ]
+        by_name = {span.name: span for span in spans}
+        expected = {
+            "worker.request_decode",
+            "worker.queue_wait",
+            "worker.forward",
+            "worker.deserialize",
+            "worker.compute_submit",
+            "worker.compute_wait",
+            "worker.serialize",
+            "worker.response_encode",
+        }
+        assert expected <= by_name.keys()
+        server_span = next(
+            span for span in spans if span.parent_span_id == bytes.fromhex(_REMOTE_PARENT_SPAN_ID)
+        )
+        for name in ("worker.request_decode", "worker.queue_wait", "worker.forward"):
+            assert by_name[name].parent_span_id == server_span.span_id
+        for name in (
+            "worker.deserialize",
+            "worker.compute_submit",
+            "worker.compute_wait",
+            "worker.serialize",
+            "worker.response_encode",
+        ):
+            assert by_name[name].parent_span_id == by_name["worker.forward"].span_id
+        assert (
+            _string_attributes(by_name["worker.forward"].attributes)[
+                "expertkit.transport"
+            ]
+            == "shm"
+        )
 
     asyncio.run(scenario())

--- a/ek-worker/tests/unit/execution/test_slot.py
+++ b/ek-worker/tests/unit/execution/test_slot.py
@@ -341,7 +341,7 @@ def test_cuda_slot_uses_one_stream_and_reuses_pinned_output() -> None:
         assert isinstance(value, float)
         assert math.isfinite(value)
         assert value >= 0
-    assert "worker.device.wait" in tracer.names
+    assert "worker.compute_wait" in tracer.names
     assert not any(name.startswith("expertkit.cuda.") for name in unsampled_span.attributes)
     second.release()
     assert slot.device_bytes == 112

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,10 @@ dependencies = [
 [project.optional-dependencies]
 fused = ["expertkit-worker[fused]==0.1.0"]
 ggml = ["expertkit-worker[ggml]==0.1.0"]
-observability = ["expertkit-worker[observability]==0.1.0"]
+observability = [
+    "expertkit-transport[observability]==0.1.0",
+    "expertkit-worker[observability]==0.1.0",
+]
 vllm = ["expertkit-vllm==0.1.0"]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -868,6 +868,7 @@ ggml = [
     { name = "expertkit-worker", extra = ["ggml"] },
 ]
 observability = [
+    { name = "expertkit-transport", extra = ["observability"] },
     { name = "expertkit-worker", extra = ["observability"] },
 ]
 vllm = [
@@ -891,6 +892,7 @@ requires-dist = [
     { name = "expertkit-proto", editable = "ek-proto" },
     { name = "expertkit-torch", editable = "ek-integration/expertkit_torch" },
     { name = "expertkit-transport", editable = "ek-transport" },
+    { name = "expertkit-transport", extras = ["observability"], marker = "extra == 'observability'", editable = "ek-transport" },
     { name = "expertkit-vllm", marker = "extra == 'vllm'", editable = "ek-integration/expertkit_vllm" },
     { name = "expertkit-worker", editable = "ek-worker" },
     { name = "expertkit-worker", extras = ["fused"], marker = "extra == 'fused'", editable = "ek-worker" },
@@ -955,14 +957,23 @@ dependencies = [
     { name = "torch" },
 ]
 
+[package.optional-dependencies]
+observability = [
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-sdk" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "expertkit-proto", editable = "ek-proto" },
     { name = "grpcio", specifier = "==1.71.0" },
     { name = "numpy", specifier = ">=2.1,<3" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'observability'", specifier = "==1.39.1" },
+    { name = "opentelemetry-sdk", marker = "extra == 'observability'", specifier = "==1.39.1" },
     { name = "protobuf", specifier = "==5.29.6" },
     { name = "torch", specifier = "==2.11.0" },
 ]
+provides-extras = ["observability"]
 
 [[package]]
 name = "expertkit-vllm"


### PR DESCRIPTION
## Summary

Add end-to-end OpenTelemetry tracing for direct Expert-Kit requests from the
frontend to workers over gRPC and shared memory.

The trace now connects frontend routing and transport spans with the
corresponding worker execution spans, making request latency attributable across
routing, serialization, transport, queueing, expert loading, compute, and
response handling.

## Changes

### Frontend tracing

Add request, layer, and worker-batch-level spans:

- `frontend.request`
- `frontend.layer`
- `frontend.decompose`
- `frontend.route`
- `frontend.worker_batch`
- `frontend.tensor_slice`
- `frontend.serialize`
- `frontend.send_worker`
- `frontend.deserialize`
- `frontend.merge`

Include request and routing attributes such as:

- instance ID
- layer ID
- topology version
- token and assignment counts
- expert IDs
- worker ID and worker start ID
- retry attempt
- transport type

### Trace-context propagation

- Inject W3C `traceparent` into frontend-to-worker gRPC metadata.
- Extract the remote trace context in gRPC and SHM worker receivers.
- Restore the remote parent before creating worker execution spans.
- Preserve the complete parent-child relationship across asynchronous tasks.
- Propagate only the trace context required by the current implementation.

### Worker tracing

Add worker-side stage spans:

- `worker.request_decode`
- `worker.queue_wait`
- `worker.forward`
- `worker.load_expert`
- `worker.deserialize`
- `worker.compute_submit`
- `worker.compute_wait`
- `worker.serialize`
- `worker.response_encode`

Expose worker identity through OpenTelemetry resource and span attributes:

- worker service name
- worker ID
- worker start ID
- backend
- device
- instance and layer IDs
- topology version
- token and expert information

### Transport visibility

Add a stable `expertkit.transport` attribute to:

- `frontend.worker_batch`
- `frontend.send_worker`
- `worker.forward`

Transport values are normalized as:

- `grpc`
- `shm`

For the SHM path, Tensor data is transferred through shared memory while gRPC
is used for control notification. Therefore, the automatically generated

<img width="1470" height="899" alt="image" src="https://github.com/user-attachments/assets/873dc4f4-b1ef-4f70-b429-c5ede289443c" />


<img width="1462" height="841" alt="image" src="https://github.com/user-attachments/assets/4c7647f7-7d61-4c7d-9166-0d30b67f2a94" />


